### PR TITLE
fix(beams): call ParaxialBeam constructor first in all beam subclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Scripts for simulation of optical beam propagation (Gaussian, Hermite-Gauss, Lag
 **Author:** Ugalde-Ontiveros J.A.
 
 [![Octave CI](https://github.com/dreamjorge/Simulation_Scripts/actions/workflows/octave.yml/badge.svg)](https://github.com/dreamjorge/Simulation_Scripts/actions/workflows/octave.yml)
+[![MATLAB CI](https://github.com/dreamjorge/Simulation_Scripts/actions/workflows/matlab.yml/badge.svg)](https://github.com/dreamjorge/Simulation_Scripts/actions/workflows/matlab.yml)
 
-## Estructura
+## Project Structure
 
 ```
 Simulation_Scripts/
@@ -71,7 +72,7 @@ Every beam type inherits from `ParaxialBeam` and implements:
 | `getParameters(z)` | `GaussianParameters` | Beam params at position z |
 | `beamName()` | `char` | String identifier like 'hermite_3_2' |
 
-## Uso Rápido
+## Quick Start
 
 ### MATLAB/Octave
 
@@ -83,24 +84,24 @@ setpaths
 addpath('src/beams', 'src/parameters', 'src/propagation/field', 'src/propagation/rays', 'src/visualization');
 addpath('ParaxialBeams', 'ParaxialBeams/Addons');
 
-% Crear beam via Factory
+% Create beam via Factory
 beam = BeamFactory.create('gaussian', 100e-6, 632.8e-9);
 
-% Usar beam directamente
+% Use beam directly
 grid = GridUtils(1024, 1024, 1e-3, 1e-3);
 [X, Y] = grid.create2DGrid();
 field = beam.opticalField(X, Y, 0);
 
-% O propagar via FFT
+% Or propagate via FFT
 prop = FFTPropagator(grid, 632.8e-9);
 field_at_z = prop.propagate(beam, 0.1);
 ```
 
-## Patrones de Diseño
+## Design Patterns
 
 ### Strategy Pattern — Propagators
 
-Tres métodos de propagación intercambiables:
+Three interchangeable propagation methods:
 
 ```matlab
 % FFT (angular spectrum)
@@ -119,7 +120,7 @@ bundle = prop.propagate(beam, z);
 ### Factory Pattern — BeamFactory
 
 ```matlab
-% Todos los beams vía Factory
+% All beams via Factory
 g  = BeamFactory.create('gaussian', 100e-6, 632.8e-9);
 hg = BeamFactory.create('hermite', 100e-6, 632.8e-9, 'n', 2, 'm', 1);
 lg = BeamFactory.create('laguerre', 100e-6, 632.8e-9, 'l', 1, 'p', 0);
@@ -127,7 +128,7 @@ lg = BeamFactory.create('laguerre', 100e-6, 632.8e-9, 'l', 1, 'p', 0);
 
 ## Canonical Examples
 
-Ejemplos recomendados para nuevos usuarios (en `examples/canonical/`):
+Recommended examples for new users (in `examples/canonical/`):
 
 | File | Description |
 |------|-------------|
@@ -135,7 +136,7 @@ Ejemplos recomendados para nuevos usuarios (en `examples/canonical/`):
 | `examples/canonical/MainMultiMode.m` | Multi-mode Hermite/Laguerre |
 | `examples/canonical/ExampleRayTracing.m` | Ray tracing visualization |
 
-## Constantes y Utilidades
+## Constants and Utilities
 
 ### PhysicalConstants
 
@@ -164,12 +165,12 @@ G = fftOps.fft2(g);
 g = fftOps.ifft2(G);
 ```
 
-## Compatibilidad
+## Compatibility
 
 - **GNU Octave 11.1.0+**
 - **MATLAB R2020b+**
 
-No se usan `classdef` folders. Todos los archivos son `.m` individuales.
+No `classdef` folders are used. All files are individual `.m` files.
 
 ## Tests
 
@@ -184,15 +185,15 @@ octave --no-gui --eval "run('tests/legacy_compat/run_legacy_compat.m')"
 matlab -batch "run('tests/test_all.m')"
 ```
 
-## Referencias
+## References
 
 - Kogelnik, H., & Li, T. (1966). Laser beams and resonators. *Applied Optics*.
 - Siegman, A. E. (1986). *Lasers*. University Science Books.
-- Referencias detalladas por implementacion (Gaussian/Hermite/Laguerre/Elegant/Hankel): `docs/ARCHITECTURE.md` -> `Referencias Bibliograficas por Implementacion`.
+- Detailed references by implementation (Gaussian/Hermite/Laguerre/Elegant/Hankel): `docs/ARCHITECTURE.md` -> `References by Implementation`.
 
-## Migracion Legacy
+## Legacy Migration
 
-- Plan incremental (Strangler): `docs/migration/LEGACY_MIGRATION_PLAN.md`
+- Incremental plan (Strangler pattern): `docs/migration/LEGACY_MIGRATION_PLAN.md`
 - Release checkpoint (2026-04-15): `docs/migration/RELEASE_CHECKPOINT_2026-04-15.md`
 
 ## Changelog

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -229,48 +229,48 @@ No `classdef` folders (@Folder). All classes in single `.m` files.
 - Kogelnik, H., & Li, T. (1966). Laser beams and resonators. *Applied Optics*.
 - Siegman, A. E. (1986). *Lasers*. University Science Books.
 
-## Referencias Bibliograficas por Implementacion
+## References by Implementation
 
 ### GaussianBeam (`src/beams/GaussianBeam.m`)
 
 - Kogelnik, H., & Li, T. (1966). *Laser Beams and Resonators*. Applied Optics, 5(10), 1550-1567.
-  - Base para el formalismo paraxial: waist `w(z)`, radio de curvatura `R(z)`, fase de Gouy `psi(z)`.
+  - Foundation for the paraxial formalism: waist `w(z)`, radius of curvature `R(z)`, Gouy phase `psi(z)`.
 - Siegman, A. E. (1986). *Lasers*. University Science Books.
-  - Referencia clasica para notacion y convenciones de fase de haces gaussianos.
+  - Classic reference for notation and phase conventions of Gaussian beams.
 
 ### HermiteBeam / LaguerreBeam (`src/beams/HermiteBeam.m`, `src/beams/LaguerreBeam.m`)
 
 - Saleh, B. E. A., & Teich, M. C. (2007). *Fundamentals of Photonics* (2nd ed.). Wiley.
-  - Derivacion de modos transversales HG/LG y estructura modal en coordenadas cartesianas/polares.
+  - Derivation of transverse HG/LG modes and modal structure in Cartesian/polar coordinates.
 - Allen, L., Beijersbergen, M. W., Spreeuw, R. J. C., & Woerdman, J. P. (1992).
   *Orbital angular momentum of light and the transformation of Laguerre-Gaussian laser modes*.
   Physical Review A, 45(11), 8185-8189.
-  - Marco para indice azimutal `l`, orden radial `p` y fase azimutal `exp(i*l*theta)`.
+  - Framework for azimuthal index `l`, radial order `p`, and azimuthal phase `exp(i*l*theta)`.
 
 ### ElegantHermiteBeam / ElegantLaguerreBeam (`src/beams/ElegantHermiteBeam.m`, `src/beams/ElegantLaguerreBeam.m`)
 
 - Siegman, A. E. (1996). *Defining and measuring laser beam quality*. JOSA A, 13(5), 952-964.
-  - Uso del parametro complejo `q(z)` y formulacion "elegant" con argumentos complejos.
+  - Use of the complex beam parameter `q(z)` and the "elegant" formulation with complex arguments.
 - Siegman, A. E. (1986). *Lasers*. University Science Books.
-  - Contexto teorico para el acople amplitud-fase en familias elegant.
+  - Theoretical context for the amplitude-phase coupling in elegant beam families.
 
 ### HankelLaguerre (`src/beams/HankelLaguerre.m`)
 
 - Kotlyar, V. V., Kovalev, A. A., & Porfirev, A. P. (2012). *Hankel beams and their properties*.
   Optics Letters / JOSA A literature on Hankel-type structured beams.
-  - Base conceptual para la combinacion `H^(1,2) = LG +/- i*XLG` usada en la implementacion.
+  - Conceptual basis for the combination `H^(1,2) = LG +/- i*XLG` used in the implementation.
 
-### Soporte MATLAB/Octave (semantica numerica)
+### MATLAB/Octave Support (numerical semantics)
 
 - MathWorks. `cart2pol` documentation.
-  - Verifica orden de salida `[theta, rho]`, usado al mapear `(X,Y)->(theta,r)`.
+  - Verifies output order `[theta, rho]`, used when mapping `(X,Y)->(theta,r)`.
 - MathWorks. Symbolic Math Toolbox `laguerreL` documentation.
-  - Convencion de polinomios de Laguerre asociados consistente con `L_p^{|l|}`.
+  - Associated Laguerre polynomial convention consistent with `L_p^{|l|}`.
 
-### Nota de Convenciones
+### Phase Convention Note
 
-- Distintas fuentes usan convenciones de fasor distintas (`exp(+i*k*z)` vs `exp(-i*k*z)`).
-- Este repositorio fija `exp(-i*k*z)` y mantiene coherencia interna en:
-  - carrier gaussiano,
-  - fase de curvatura,
-  - fase de Gouy modal (`exp(-i*phi_mode)`).
+- Different sources use different phasor conventions (`exp(+i*k*z)` vs `exp(-i*k*z)`).
+- This repository uses `exp(-i*k*z)` and maintains internal consistency across:
+  - Gaussian carrier,
+  - curvature phase,
+  - modal Gouy phase (`exp(-i*phi_mode)`).

--- a/docs/plans/2026-04-12-refactor-utility-classes.md
+++ b/docs/plans/2026-04-12-refactor-utility-classes.md
@@ -1,37 +1,37 @@
-# Refactor Completo — `refactor/utility-classes` Implementation Plan
+# Full Refactor — `refactor/utility-classes` Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Arreglar todos los issues técnicos del branch refactor/utility-classes antes de hacer PR.
+**Goal:** Fix all technical issues on the refactor/utility-classes branch before creating a PR.
 
 **Architecture:**
-- **GridUtils**: Fix static methods `meshgrid2D` y `freqGrid` para soportar Nx/Ny separados
-- **ElegantHermiteBeam**: Eliminar uso innecesario de `cart2pol` — compute R directamente
-- **Elegant beam naming**: Estandarizar a lowercase `x,y` para coordenadas cartesianas
-- **Backwards-compat wrappers**: Remover `HermiteBeam.hermitePoly()` y `LaguerreParameters.getAssociatedLaguerrePolynomial()`
-- **HankelLaguerre**: Implementar con formula real descubierta en git history
-- **AnalysisUtils.combinedHankelWave**: Decidir si implementar o remover stub
-- **Addons/Addons que llaman a stubs**: getPropagateCylindricalRays y getPropagateRay — SI se usan
-- **Test compatibility**: Reemplazar `exit(0)/exit(1)` con `assert()` para MATLAB compatibilidad
+- **GridUtils**: Fix static methods `meshgrid2D` and `freqGrid` to support separate Nx/Ny
+- **ElegantHermiteBeam**: Remove unnecessary `cart2pol` usage — compute R directly
+- **Elegant beam naming**: Standardize to lowercase `x,y` for Cartesian coordinates
+- **Backwards-compat wrappers**: Remove `HermiteBeam.hermitePoly()` and `LaguerreParameters.getAssociatedLaguerrePolynomial()`
+- **HankelLaguerre**: Implement with the real formula discovered in git history
+- **AnalysisUtils.combinedHankelWave**: Decide whether to implement or remove stub
+- **Addons calling stubs**: getPropagateCylindricalRays and getPropagateRay — ARE used
+- **Test compatibility**: Replace `exit(0)/exit(1)` with `assert()` for MATLAB compatibility
 
 **Tech Stack:** Octave/MATLAB, classdef, (no framework — vanilla scripts)
 
 ---
 
-## Task 1: Investigar HankelLaguerre y archivos relacionados ✅ (COMPLETADO)
+## Task 1: Investigate HankelLaguerre and related files (COMPLETED)
 
-**Investigación completada:**
+**Investigation completed:**
 
-### Archivos que usan getPropagateCylindricalRays:
-- `MainLaguerre.m` — líneas 206, 218
-- `MainLaguerre2.m` — líneas 203, 215
-- `MaineLaguerreForTest.m` — líneas 203, 215
-- `AnalysisExperimentalLaguerre.m` — líneas 207-225
+### Files using getPropagateCylindricalRays:
+- `MainLaguerre.m` — lines 206, 218
+- `MainLaguerre2.m` — lines 203, 215
+- `MaineLaguerreForTest.m` — lines 203, 215
+- `AnalysisExperimentalLaguerre.m` — lines 207-225
 
-### Fórmula real de HankelLaguerre (descubierta en commit 981b7b1):
+### Real HankelLaguerre formula (discovered in commit 981b7b1):
 
 ```matlab
-% Del @HankelLaguerre legacy (MATLAB class folder):
+% From legacy @HankelLaguerre (MATLAB class folder):
 if nh == 1
     Hankel.OpticalFieldLaguerre = LB.OpticalFieldLaguerre + 1i*XLB.OpticalFieldLaguerre;
 elseif nh == 2
@@ -39,19 +39,19 @@ elseif nh == 2
 end
 ```
 
-Donde XLaguerreBeam usa:
-- `exp(-1i*abs(p)*theta)` vs `exp(1i*l*theta)` en fase
-- `XAssociatedLaguerrePolynomial(l,abs(p),xArg)` = `associatedLaguerre(p, l, x)` (orden swapped!)
+Where XLaguerreBeam uses:
+- `exp(-1i*abs(p)*theta)` vs `exp(1i*l*theta)` in phase
+- `XAssociatedLaguerrePolynomial(l,abs(p),xArg)` = `associatedLaguerre(p, l, x)` (args in different order!)
 
 ---
 
-## Task 2: Implementar HankelLaguerre — Formula real
+## Task 2: Implement HankelLaguerre — Real formula
 
 **Files:**
 - Modify: `ParaxialBeams/HankelLaguerre.m`
 - Create: `tests/test_HankelLaguerre.m`
 
-**Step 1: Escribir test primero**
+**Step 1: Write test first**
 
 ```matlab
 #!/usr/bin/env octave
@@ -119,7 +119,7 @@ end
 try
     HL1 = HankelLaguerre(r, theta, params, 1);
     HL2 = HankelLaguerre(r, theta, params, 2);
-    % H1 + H2 should equal 2*LB (imag parts cancel)
+    % H1 + H2 should equal 2*LB (imaginary parts cancel)
     diff = HL1.OpticalFieldLaguerre + HL2.OpticalFieldLaguerre;
     LB = LaguerreBeam(r, theta, params);
     if max(max(abs(diff - 2*LB.OpticalField))) < 1e-10
@@ -146,7 +146,7 @@ Expected: FAIL (current stub throws error)
 
 **Step 2: Implement HankelLaguerre**
 
-Reemplazar todo el contenido de `ParaxialBeams/HankelLaguerre.m`:
+Replace the entire content of `ParaxialBeams/HankelLaguerre.m`:
 
 ```matlab
 classdef HankelLaguerre
@@ -156,7 +156,7 @@ classdef HankelLaguerre
     % Implements: HL^{(p,l)}_1 = LB + 1i*XLG
     %             HL^{(p,l)}_2 = LB - 1i*XLG
     %
-    % Where LB is standard LaguerreBeam and XLG is the Hilbert-transformed
+    % Where LB is the standard LaguerreBeam and XLG is the Hilbert-transformed
     % counterpart with:
     %   - Phase: exp(-1i*p*theta) instead of exp(1i*l*theta)
     %   - Polynomial: AssociatedLaguerre(p, l, x) (args in different order)
@@ -205,7 +205,7 @@ function field = computeHankelField(r, theta, params, hankelType)
     
     % XLG (Hilbert-transformed) field:
     % - Phase uses exp(-1i*p*theta) instead of exp(1i*l*theta)
-    % - Polynomial uses associatedLaguerre(p, l, x) which is what we already have!
+    % - Polynomial uses associatedLaguerre(p, l, x) which is what we already have
     XLG_field = amp .* Lpl .* exp(-1i * p * theta) .* exp(1i * params.PhiPhase) .* GField;
     
     % Combine via Hankel type
@@ -237,14 +237,14 @@ git commit -m "feat(HankelLaguerre): implement Hankel-type LG beam field"
 **Step 1: Fix meshgrid2D static method**
 
 ```matlab
-% ANTES (line 72-75):
+% BEFORE (line 72-75):
 function [X, Y] = meshgrid2D(N, D)
     n = -N/2:N/2-1;
     x = n * (D / N);
     [X, Y] = meshgrid(x, x);
 end
 
-% NUEVO (line 72-79):
+% NEW (line 72-79):
 function [X, Y] = meshgrid2D(Nx, Ny, Dx, Dy)
     % meshgrid2D - Create 2D coordinate grid
     % Supports asymmetric grids when Nx~=Ny or Dx~=Dy
@@ -263,14 +263,14 @@ end
 **Step 2: Fix freqGrid static method**
 
 ```matlab
-% ANTES (line 81-85):
+% BEFORE (line 81-85):
 function [Kx, Ky] = freqGrid(N, D)
     n = -N/2:N/2-1;
     u = n * (1 / D);
     [Kx, Ky] = meshgrid(2*pi*u, 2*pi*u);
 end
 
-% NUEVO (line 81-91):
+% NEW (line 81-91):
 function [Kx, Ky] = freqGrid(Nx, Ny, Dx, Dy)
     % freqGrid - Create frequency domain grid
     % Supports asymmetric grids when Nx~=Ny or Dx~=Dy
@@ -286,16 +286,16 @@ function [Kx, Ky] = freqGrid(Nx, Ny, Dx, Dy)
 end
 ```
 
-**Step 3: Fix polarGrid (llama a meshgrid2D)**
+**Step 3: Fix polarGrid (calls meshgrid2D)**
 
 ```matlab
-% ANTES (line 93-96):
+% BEFORE (line 93-96):
 function [r, theta] = polarGrid(N, D)
     [X, Y] = GridUtils.meshgrid2D(N, D);
     [r, theta] = cart2pol(X, Y);
 end
 
-% NUEVO (line 93-101):
+% NEW (line 93-101):
 function [r, theta] = polarGrid(Nx, Ny, Dx, Dy)
     % polarGrid - Create polar coordinate grid
     % Supports asymmetric grids when Nx~=Ny or Dx~=Dy
@@ -308,10 +308,10 @@ function [r, theta] = polarGrid(Nx, Ny, Dx, Dy)
 end
 ```
 
-**Step 4: Correr tests**
+**Step 4: Run tests**
 
 Run: `octave tests/test_GridUtils.m`
-Expected: PASS (backwards compat mantener N,D funcionando)
+Expected: PASS (backwards compat keeps N,D working)
 
 **Step 5: Commit**
 ```bash
@@ -321,32 +321,32 @@ git commit -m "fix(GridUtils): static methods now support asymmetric grids"
 
 ---
 
-## Task 4: Estandarizar naming en Elegant beams
+## Task 4: Standardize naming in Elegant beams
 
 **Files:**
 - Modify: `ParaxialBeams/ElegantHermiteBeam.m`
 
-**Step 1: Analizar convencion actual**
+**Step 1: Analyze current convention**
 
-- `HermiteBeam`: usa `x`, `y` (lowercase)
-- `ElegantHermiteBeam`: usa `X`, `Y` (uppercase) — INCONSISTENTE
-- `ElegantLaguerreBeam`: usa `r`, `theta` (correcto para cilíndricas)
+- `HermiteBeam`: uses `x`, `y` (lowercase)
+- `ElegantHermiteBeam`: uses `X`, `Y` (uppercase) — INCONSISTENT
+- `ElegantLaguerreBeam`: uses `r`, `theta` (correct for cylindrical)
 
-Elegir convencion: **lowercase** (`x`, `y`) para consistencia con `HermiteBeam`.
+Chosen convention: **lowercase** (`x`, `y`) for consistency with `HermiteBeam`.
 
 **Step 2: Fix ElegantHermiteBeam**
 
 ```matlab
-% ANTES (propiedades, lines 7-8):
+% BEFORE (properties, lines 7-8):
 X               % X coordinate matrix
 Y               % Y coordinate matrix
 
-% NUEVO (propiedades):
+% NEW (properties):
 x               % x coordinate matrix
 y               % y coordinate matrix
 
-% Constructor (lines 12-17) cambiar X,Y por x,y en todo
-% Tambien line 21: argX = sqrt_alpha .* X; -> argX = sqrt_alpha .* x;
+% Constructor (lines 12-17) change X,Y to x,y throughout
+% Also line 21: argX = sqrt_alpha .* X; -> argX = sqrt_alpha .* x;
 % Line 22: argY = sqrt_alpha .* Y; -> argY = sqrt_alpha .* y;
 % Line 29: [R, ~] = cart2pol(X, Y); -> [R, ~] = cart2pol(x, y);
 ```
@@ -359,23 +359,23 @@ git commit -m "refactor(ElegantHermiteBeam): standardize to lowercase x,y"
 
 ---
 
-## Task 5: Eliminar backwards-compat wrappers
+## Task 5: Remove backwards-compat wrappers
 
 **Files:**
-- Modify: `ParaxialBeams/HermiteBeam.m` (remover método estático hermitePoly)
-- Modify: `ParaxialBeams/LaguerreParameters.m` (remover método estático getAssociatedLaguerrePolynomial)
+- Modify: `ParaxialBeams/HermiteBeam.m` (remove static method hermitePoly)
+- Modify: `ParaxialBeams/LaguerreParameters.m` (remove static method getAssociatedLaguerrePolynomial)
 
-**Step 1: Buscar usages de estos wrappers**
+**Step 1: Search for usages of these wrappers**
 
 ```bash
 grep -r "HermiteBeam.hermitePoly\|LaguerreParameters.getAssociatedLaguerrePolynomial" /root/Simulation_Scripts --include="*.m"
 ```
 
-Expected: solo las definiciones (no se usan)
+Expected: only the definitions (not used elsewhere)
 
-**Step 2: Remover wrappers**
+**Step 2: Remove wrappers**
 
-De `HermiteBeam.m` líneas 45-50 remover el bloque completo:
+From `HermiteBeam.m` lines 45-50 remove the entire block:
 ```matlab
 methods (Static)
     function H = hermitePoly(n, x)
@@ -384,7 +384,7 @@ methods (Static)
 end
 ```
 
-De `LaguerreParameters.m` líneas 59-62 remover solo `getAssociatedLaguerrePolynomial`:
+From `LaguerreParameters.m` lines 59-62 remove only `getAssociatedLaguerrePolynomial`:
 ```matlab
 methods (Static)
     function wL = getWaist(z, w0, zr, l, p)
@@ -398,7 +398,7 @@ methods (Static)
 end
 ```
 
-**Mantener** `getWaist` (es útil) pero remover `getAssociatedLaguerrePolynomial`.
+**Keep** `getWaist` (it's useful) but remove `getAssociatedLaguerrePolynomial`.
 
 **Step 3: Commit**
 ```bash
@@ -408,29 +408,29 @@ git commit -m "refactor: remove backwards-compat wrappers"
 
 ---
 
-## Task 6: Fix ElegantHermiteBeam cart2pol innecesario
+## Task 6: Fix ElegantHermiteBeam unnecessary cart2pol
 
 **Files:**
 - Modify: `ParaxialBeams/ElegantHermiteBeam.m`
 
-**Step 1: Analizar**
+**Step 1: Analyze**
 
-El código actual (línea 29):
+The current code (line 29):
 ```matlab
 [R, ~] = cart2pol(X, Y);
 GB = GaussianBeam(R, params);
 ```
 
-Pero `GaussianBeam` recibe `r` (radial), no necesita `theta`. El `cart2pol` computa theta que se descarta.
+But `GaussianBeam` receives `r` (radial), it doesn't need `theta`. The `cart2pol` computes theta which is discarded.
 
-**Step 2: Compute R directamente**
+**Step 2: Compute R directly**
 
 ```matlab
-% ANTES:
+% BEFORE:
 [R, ~] = cart2pol(X, Y);
 GB = GaussianBeam(R, params);
 
-% NUEVO:
+% NEW:
 R = sqrt(X.^2 + Y.^2);
 GB = GaussianBeam(R, params);
 ```
@@ -443,29 +443,29 @@ git commit -m "fix(ElegantHermiteBeam): compute radius directly instead of cart2
 
 ---
 
-## Task 7: Test compatibility — reemplazar exit() con assert()
+## Task 7: Test compatibility — replace exit() with assert()
 
 **Files:**
-- Modify: `tests/*.m` (todos los archivos de test)
+- Modify: `tests/*.m` (all test files)
 
-**Step 1: Reemplazar exit() con assert()**
+**Step 1: Replace exit() with assert()**
 
-Patrón a buscar en cada test file:
+Pattern to search for in each test file:
 ```matlab
-% ANTES:
+% BEFORE:
 if failed == 0
     exit(0);
 else
     exit(1);
 end
 
-% NUEVO:
+% NEW:
 if failed ~= 0
     error('Tests failed: %d/%d', failed, passed + failed);
 end
 ```
 
-Hacerlo para todos los test files:
+Apply to all test files:
 - test_all.m
 - test_GridUtils.m
 - test_FFTUtils.m
@@ -490,35 +490,35 @@ git commit -m "test: replace exit() with assert() for MATLAB compatibility"
 
 ---
 
-## Task 8: Revisar AnalysisUtils.combinedHankelWave
+## Task 8: Review AnalysisUtils.combinedHankelWave
 
 **Files:**
 - Analyze: `ParaxialBeams/AnalysisUtils.m`
-- Analyze: `ParaxialBeams/HankelLaguerre.m` (note sobre combinedHankelWave)
+- Analyze: `ParaxialBeams/HankelLaguerre.m` (note about combinedHankelWave)
 
-**Step 1: Buscar usages**
+**Step 1: Search for usages**
 
 ```bash
 grep -r "combinedHankelWave" /root/Simulation_Scripts --include="*.m"
 ```
 
-**Step 2: Si no se usa**
+**Step 2: If unused**
 
-Este stub hace referencia a `HankelHermiteSlices.m`. No se encontró en el código actual. Remover el stub y su comentario de error.
+This stub references `HankelHermiteSlices.m`. It was not found in the current code. Remove the stub and its error comment.
 
 ---
 
-## Task 9: Run full test suite y verification
+## Task 9: Run full test suite and verification
 
-**Step 1: Correr todos los tests**
+**Step 1: Run all tests**
 
 ```bash
 cd /root/Simulation_Scripts && octave tests/test_all.m
 ```
 
-Expected: Todos PASS
+Expected: All PASS
 
-**Step 2: Verificar coverage**
+**Step 2: Verify coverage**
 
 ```bash
 octave tests/run_coverage.m
@@ -528,21 +528,21 @@ octave tests/run_coverage.m
 
 ## Pre-PR Checklist
 
-- [ ] HankelLaguerre implementado y testeado
-- [ ] GridUtils static methods fix con backwards compat
-- [ ] ElegantHermiteBeam naming (x,y) y cart2pol fix
-- [ ] Backwards-compat wrappers removidos
-- [ ] Tests con error() en vez de exit()
-- [ ] AnalysisUtils.combinedHankelWave stub removido si no se usa
-- [ ] Todos los tests pasando
-- [ ] No nuevas advertencias
+- [ ] HankelLaguerre implemented and tested
+- [ ] GridUtils static methods fixed with backwards compat
+- [ ] ElegantHermiteBeam naming (x,y) and cart2pol fix
+- [ ] Backwards-compat wrappers removed
+- [ ] Tests use error() instead of exit()
+- [ ] AnalysisUtils.combinedHankelWave stub removed if unused
+- [ ] All tests passing
+- [ ] No new warnings
 
 ---
 
-## Riscos
+## Risks
 
-1. **Implementación HankelLaguerre**: La formula real requiere XLaguerreBeam que tiene normalización extra — verificar con scripts reales
-2. **Breaking backwards compat**: GridUtils ahora soporta Nx,Ny,Dx,Dy — signature changed pero con backwards compat
-3. **Breaking backwards compat wrappers**: Los wrappers removidos eran solo para backwards — verificar que no se usen externamente
+1. **HankelLaguerre implementation**: The real formula requires XLaguerreBeam which has extra normalization — verify with actual scripts
+2. **Breaking backwards compat**: GridUtils now supports Nx,Ny,Dx,Dy — signature changed but with backwards compat
+3. **Breaking backwards compat wrappers**: The removed wrappers were only for backwards compatibility — verify they are not used externally
 
-**Mitigación**: Tests primero, commits atômicos, validación manual antes de PR.
+**Mitigation**: Tests first, atomic commits, manual validation before PR.

--- a/openspec/changes/pre-merge-hardening/proposal.md
+++ b/openspec/changes/pre-merge-hardening/proposal.md
@@ -2,78 +2,79 @@
 
 ## Intent
 
-Consolidar y documentar el estado actual de `integration/pre-master` para un merge limpio a `master`. El branch tiene 71 commits de refactorización masiva (Strategy/Factory patterns, ~380 tests, CI/CD para MATLAB/Octave) pero carece de documentación que refleje la realidad del código. Sin este trabajo, el merge perpetúa la desalineación entre docs y código.
+Consolidate and document the current state of `integration/pre-master` for a clean merge to `master`. The branch has 71 commits of massive refactoring (Strategy/Factory patterns, ~380 tests, CI/CD for MATLAB/Octave) but lacks documentation that reflects the reality of the code. Without this work, the merge perpetuates the misalignment between docs and code.
 
 ## Scope
 
 ### In Scope
-- Actualizar `README.md` con estructura real del repo (27 archivos .m en ParaxialBeams)
-- Crear `docs/ARCHITECTURE.md` con diagrama de clases y patrones aplicados
-- Documentar API pública de beams (contrato `opticalField`, `getParameters`, `beamName`)
-- Clasificar ejemplos como `canonical` vs `legacy` en `README.md`
-- Completar checklist de merge readiness en `plan.md`
-- Agregar CHANGELOG.md o conventional commits al merge
-- Unificar branches redundantes (`exec/pre-merge-hardening` vs `integration/pre-master`)
+- Update `README.md` with the actual repo structure (27 .m files in ParaxialBeams)
+- Create `docs/ARCHITECTURE.md` with class diagram and applied patterns
+- Document the public beam API (contract: `opticalField`, `getParameters`, `beamName`)
+- Classify examples as `canonical` vs `legacy` in `README.md`
+- Complete the merge readiness checklist in `plan.md`
+- Add CHANGELOG.md or conventional commits for the merge
+- Unify redundant branches (`exec/pre-merge-hardening` vs `integration/pre-master`)
 
 ### Out of Scope
-- Package migration a `+paraxial/` namespaces (post-merge)
-- Re-diseño OO de beams/propagators (post-merge)
-- Reescritura total de ejemplos históricos (post-merge)
-- Rescate de ramas legacy completas
+- Package migration to `+paraxial/` namespaces (post-merge)
+- Deep OO redesign of beams/propagators (post-merge)
+- Full rewrite of historical examples (post-merge)
+- Rescue of complete legacy branches
+- Major structural cleanup of third-party addons
 
 ## Capabilities
 
 ### New Capabilities
-- `pre-merge-docs`: Documentación de arquitectura y API para facilitar merge a master
+- `pre-merge-docs`: Architecture and API documentation to facilitate merge to master
 
 ### Modified Capabilities
-- `beam-api`: El contrato existente de ParaxialBeam se documenta formalmente pero no cambia
+- `beam-api`: The existing ParaxialBeam contract is formally documented but does not change
 
 ## Approach
 
-1. **Auditoría de API**: Leer los 6 archivos de beam classes y verificar que cumplen el contrato `opticalField(X,Y,z)`, `getParameters(z)`, `beamName()`
-2. **Documentación canónica**: Crear `docs/ARCHITECTURE.md` con estructura de clases, patrones, y flujo de datos
-3. **README.md rewrite**: Reemplazar estructura vieja ( `@Carpeta/` ) con realidad actual ( `.m` files)
-4. **Clasificación de ejemplos**: Marcar `examples/MainGauss_refactored.m`, `examples/MainMultiMode.m`, `ExampleRayTracing.m` como canonical
-5. **Unificación de branches**: Comparar `exec/pre-merge-hardening` con `integration/pre-master` y consolidar o archivar
+1. **API Audit**: Read the 6 beam class files and verify they comply with the `opticalField(X,Y,z)`, `getParameters(z)`, `beamName()` contract
+2. **Canonical Documentation**: Create `docs/ARCHITECTURE.md` with class structure, patterns, and data flow
+3. **README.md rewrite**: Replace old structure (`@Folder/`) with actual reality (`.m` files)
+4. **Example classification**: Mark `examples/MainGauss_refactored.m`, `examples/MainMultiMode.m`, `ExampleRayTracing.m` as canonical
+5. **Branch unification**: Compare `exec/pre-merge-hardening` with `integration/pre-master` and consolidate or archive
 
 ## Affected Areas
 
 | Area | Impact | Description |
 |------|--------|-------------|
-| `README.md` | Modified | Estructura actual, ejemplos canonicales, MATLAB/Octave compatibility |
-| `plan.md` | Modified | Completar readiness checklist pre-merge |
-| `docs/ARCHITECTURE.md` | New | Diagrama de clases, patrones Strategy/Factory, flujo de datos |
-| `examples/` | Modified | Clasificar scripts como canonical vs legacy |
-| `openspec/` | New | Estructura SDD para tracking |
+| `README.md` | Modified | Actual structure, canonical examples, MATLAB/Octave compatibility |
+| `plan.md` | Modified | Complete readiness checklist for pre-merge |
+| `docs/ARCHITECTURE.md` | New | Class diagram, Strategy/Factory patterns, data flow |
+| `examples/` | Modified | Classify scripts as canonical vs legacy |
+| `openspec/` | New | SDD structure for tracking |
 
 ## Risks
 
 | Risk | Likelihood | Mitigation |
 |------|------------|------------|
-| Conflictos entre `exec/pre-merge-hardening` e `integration/pre-master` | Medium | Hacer diff de ambas vs master y decidir cuál absorber |
-| `README.md` desactualizado confunde usuarios post-merge | High | Verificación cruzada con `ls ParaxialBeams/*.m` antes de commit |
-| Tests quebrados en MATLAB (solo verificado en Octave) | Low | CI ya tiene workflow de MATLAB |
+| Conflicts between `exec/pre-merge-hardening` and `integration/pre-master` | Medium | Diff both against master and decide which to absorb |
+| Outdated `README.md` confuses users post-merge | High | Cross-verify with `ls ParaxialBeams/*.m` before commit |
+| Broken tests in MATLAB (only verified in Octave) | Low | CI already has MATLAB workflow |
 
 ## Rollback Plan
 
 ```bash
-# Si el merge tiene problemas:
+# If the merge has issues:
 git revert <merge-commit>
 git checkout master
-# Restaurar docs desde el commit anterior al merge
+# Restore docs from the commit prior to the merge
 ```
 
 ## Dependencies
 
-- GitHub Actions CI passing para Octave y MATLAB (ya configurado)
-- 71 commits de refactor en `integration/pre-master` verificados
+- GitHub Actions CI passing for Octave and MATLAB (already configured)
+- 71 refactor commits in `integration/pre-master` verified
 
 ## Success Criteria
 
-- [ ] `README.md` refleja estructura real: `ls ParaxialBeams/*.m | wc -l` = 27 archivos documentados
-- [ ] `docs/ARCHITECTURE.md` existe con diagrama de arquitectura
-- [ ] `plan.md` tiene todos los items de pre-merge checklist marcados ✅
-- [ ] Ejemplos canonicales identificados y documentados
-- [ ] `exec/pre-merge-hardening` archivado o mergeado
-- [ ] Merge commit sigue conventional commits: `merge(integration): stabilize beam API...`
+- [ ] `README.md` reflects actual structure: `ls ParaxialBeams/*.m | wc -l` = 27 files documented
+- [ ] `docs/ARCHITECTURE.md` exists with architecture diagram
+- [ ] `plan.md` has all pre-merge checklist items marked as complete
+- [ ] Canonical examples identified and documented
+- [ ] `exec/pre-merge-hardening` archived or merged
+- [ ] Merge commit follows conventional commits: `merge(integration): stabilize beam API...`

--- a/plan.md
+++ b/plan.md
@@ -2,29 +2,29 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** dejar `integration/pre-master` listo para mergearse a `master/main` con alcance congelado, API pública auditada, ejemplos canónicos definidos y evidencia real de compatibilidad MATLAB/Octave.
+**Goal:** Make `integration/pre-master` ready for merging to `master/main` with frozen scope, audited public API, defined canonical examples, and real evidence of MATLAB/Octave compatibility.
 
-**Architecture:** este trabajo es de hardening, no de rediseño. La implementación se apoya en tres superficies reales del repo: código fuente en `ParaxialBeams/`, pruebas en `tests/` y narrativa pública en `README.md`. Cada cambio tiene que reducir ambiguedad sin reabrir la arquitectura OO.
+**Architecture:** This is hardening work, not a redesign. The implementation relies on three real surfaces of the repo: source code in `ParaxialBeams/`, tests in `tests/`, and public narrative in `README.md`. Every change must reduce ambiguity without reopening the OO architecture.
 
-**Tech Stack:** MATLAB, Octave, scripts `.m`, test runner `tests/test_all.m`, runner portátil `tests/portable_runner.m`, Git/GitHub Actions.
+**Tech Stack:** MATLAB, Octave, `.m` scripts, test runner `tests/test_all.m`, portable runner `tests/portable_runner.m`, Git/GitHub Actions.
 
 ---
 
 ## Merge Scope Checklist
 
-- [x] `ParaxialBeams/*.m` modernos auditados (27 archivos verificados)
-- [x] `tests/` vigentes y ejecutables en Octave/MATLAB (~380 tests)
-- [x] compatibilidad y portabilidad preservadas (Octave 11.1.0+, MATLAB R2020b+)
-- [x] ejemplos canónicos identificados (3 ejemplos canonical)
-- [x] narrativa pública alineada con el estado real (README.md actualizado)
+- [x] Modern `ParaxialBeams/*.m` audited (27 files verified)
+- [x] `tests/` current and runnable in Octave/MATLAB (~380 tests)
+- [x] Compatibility and portability preserved (Octave 11.1.0+, MATLAB R2020b+)
+- [x] Canonical examples identified (3 canonical examples)
+- [x] Public narrative aligned with actual state (README.md updated)
 
 ## Explicitly Out of Scope
 
-- package migration a `+paraxial/...`
-- rediseño OO profundo de beams/propagators
-- reescritura total de ejemplos históricos
-- rescate de ramas legacy completas
-- limpieza estructural grande de addons terceros
+- Package migration to `+paraxial/...`
+- Deep OO redesign of beams/propagators
+- Full rewrite of historical examples
+- Rescue of complete legacy branches
+- Major structural cleanup of third-party addons
 
 ---
 
@@ -36,32 +36,32 @@
 
 **Step 1: Document the in-scope deliverables**
 
-Agregar una checklist de merge scope en `plan.md` con estos items exactos:
+Add a merge scope checklist to `plan.md` with these exact items:
 
 ```md
-- [ ] `ParaxialBeams/*.m` modernos auditados
-- [ ] `tests/` vigentes y ejecutables en Octave/MATLAB
-- [ ] compatibilidad y portabilidad preservadas
-- [ ] ejemplos canónicos identificados
-- [ ] narrativa pública alineada con el estado real
+- [ ] Modern `ParaxialBeams/*.m` audited
+- [ ] `tests/` current and runnable in Octave/MATLAB
+- [ ] Compatibility and portability preserved
+- [ ] Canonical examples identified
+- [ ] Public narrative aligned with actual state
 ```
 
 **Step 2: Document the out-of-scope work**
 
-Agregar una sección `## Explicitly Out of Scope` en `plan.md` con estos items:
+Add an `## Explicitly Out of Scope` section to `plan.md` with these items:
 
 ```md
-- package migration a `+paraxial/...`
-- rediseño OO profundo de beams/propagators
-- reescritura total de ejemplos históricos
-- rescate de ramas legacy completas
-- limpieza estructural grande de addons terceros
+- Package migration to `+paraxial/...`
+- Deep OO redesign of beams/propagators
+- Full rewrite of historical examples
+- Rescue of complete legacy branches
+- Major structural cleanup of third-party addons
 ```
 
 **Step 3: Verify the plan still describes a stabilization merge**
 
-Run: revisar `plan.md` y confirmar que no aparece trabajo de rediseño como prerequisito del merge.
-Expected: el documento separa explícitamente hardening pre-merge vs. rediseño post-merge.
+Run: review `plan.md` and confirm that no redesign work appears as a prerequisite for the merge.
+Expected: the document explicitly separates pre-merge hardening vs. post-merge redesign.
 
 **Step 4: Commit**
 
@@ -84,30 +84,30 @@ git commit -m "docs: freeze pre-merge scope"
 
 **Step 1: Write the failing audit checklist**
 
-Agregar en `plan.md` una tabla `API Audit Matrix` con columnas `Class`, `Primary field method`, `Accepted coordinates`, `z semantics`, `Uses Parameters state`, `Status`.
+Add an `API Audit Matrix` table to `plan.md` with columns `Class`, `Primary field method`, `Accepted coordinates`, `z semantics`, `Uses Parameters state`, `Status`.
 
 **Step 2: Run the audit against the real classes**
 
-Run: leer los seis archivos de beam y completar la tabla solo con evidencia del código.
-Expected: toda fila queda marcada como `aligned`, `document-only`, o `needs-fix`.
+Run: read the six beam files and fill in the table using only code evidence.
+Expected: every row is marked as `aligned`, `document-only`, or `needs-fix`.
 
 **Step 3: Document the canonical contract**
 
-Agregar en `README.md` una sección corta con este formato:
+Add a short section to `README.md` with this format:
 
 ```md
 ## Beam API Contract
 
-- canonical field entrypoint: `opticalField(...)`
-- `Parameters` define constantes/modelo, no reemplaza argumentos dinámicos ambiguamente
-- cada beam debe declarar sus coordenadas aceptadas
-- cualquier desvío temporal queda documentado hasta el post-merge cleanup
+- Canonical field entrypoint: `opticalField(...)`
+- `Parameters` defines constants/model, does not ambiguously replace dynamic arguments
+- Each beam must declare its accepted coordinates
+- Any temporary deviations are documented until post-merge cleanup
 ```
 
 **Step 4: Re-run the audit summary**
 
-Run: verificar que `README.md` y `plan.md` usen el mismo contrato textual.
-Expected: no hay contradicciones entre plan y documentación pública.
+Run: verify that `README.md` and `plan.md` use the same contract text.
+Expected: no contradictions between plan and public documentation.
 
 **Step 5: Commit**
 
@@ -127,21 +127,21 @@ git commit -m "docs: document public beam api contract"
 
 **Step 1: Create the example classification table**
 
-Agregar en `plan.md` una tabla `Example Classification` con columnas `File`, `Tier`, `Reason`, `Action`.
+Add an `Example Classification` table to `plan.md` with columns `File`, `Tier`, `Reason`, `Action`.
 
 **Step 2: Audit the candidate examples**
 
-Run: leer los scripts candidatos y clasificarlos como `canonical`, `legacy-usable`, o `historical`.
-Expected: hay entre 3 y 5 ejemplos `canonical`.
+Run: read the candidate scripts and classify them as `canonical`, `legacy-usable`, or `historical`.
+Expected: between 3 and 5 `canonical` examples.
 
 **Step 3: Point the public docs to canonical entrypoints only**
 
-Actualizar `README.md` para que la sección de uso apunte solo a los ejemplos `canonical` elegidos.
+Update `README.md` so that the usage section points only to the chosen `canonical` examples.
 
 **Step 4: Verify no legacy example is presented as the default**
 
-Run: revisar `README.md`.
-Expected: el primer camino de entrada del usuario nuevo pasa por ejemplos auditados, no por scripts históricos ambiguos.
+Run: review `README.md`.
+Expected: the first path for new users goes through audited examples, not ambiguous historical scripts.
 
 **Step 5: Commit**
 
@@ -166,33 +166,33 @@ git commit -m "docs: classify canonical examples"
 
 **Step 1: Write the failing coverage checklist**
 
-Agregar en `plan.md` una checklist `Critical Coverage Gates` con estos checks exactos:
+Add a `Critical Coverage Gates` checklist to `plan.md` with these exact checks:
 
 ```md
-- [ ] `z = 0` no produce NaN/Inf inválidos
-- [ ] modo cero Hermite/Laguerre mantiene equivalencia razonable con Gaussian
-- [ ] ray tracing cilíndrico sigue estable
-- [ ] `tests/test_all.m` corre vía `portable_runner()`
-- [ ] el runner funciona en Octave y MATLAB
+- [ ] `z = 0` does not produce invalid NaN/Inf
+- [ ] Zero-order Hermite/Laguerre maintains reasonable equivalence with Gaussian
+- [ ] Cylindrical ray tracing remains stable
+- [ ] `tests/test_all.m` runs via `portable_runner()`
+- [ ] The runner works in both Octave and MATLAB
 ```
 
 **Step 2: Run the portable suite in Octave**
 
 Run: `octave --no-gui --eval "run('tests/test_all.m')"`
-Expected: exit code `0` y mensaje `=== ÉXITO: Todos los tests pasaron ===`.
+Expected: exit code `0` and message indicating all tests passed.
 
 **Step 3: Run the suite in MATLAB**
 
 Run: `matlab -batch "run('tests/test_all.m')"`
-Expected: ejecución sin excepción y suite verde.
+Expected: execution without exceptions and green suite.
 
 **Step 4: Document any remaining coverage gaps**
 
-Si algún check de la checklist no está cubierto, registrar el gap en `plan.md` con formato `Gap -> owner -> pre-merge/post-merge`.
+If any checklist item is not covered, record the gap in `plan.md` with format `Gap -> owner -> pre-merge/post-merge`.
 
 **Step 5: Align the testing docs**
 
-Actualizar `tests/README.md` para que el comando principal coincida con el runner real y los coverage gates auditados.
+Update `tests/README.md` so that the main command matches the real runner and the audited coverage gates.
 
 **Step 6: Commit**
 
@@ -210,25 +210,25 @@ git commit -m "test: lock critical pre-merge coverage gates"
 
 **Step 1: Identify stale claims**
 
-Run: revisar `README.md` y `tests/README.md` buscando estructura inexistente, ejemplos obsoletos o comandos de test inconsistentes.
-Expected: lista explícita de claims a corregir.
+Run: review `README.md` and `tests/README.md` looking for nonexistent structure, obsolete examples, or inconsistent test commands.
+Expected: explicit list of claims to fix.
 
 **Step 2: Apply minimal narrative fixes**
 
-Corregir únicamente estas superficies:
+Fix only these surfaces:
 
 ```md
-- estructura real del repo
-- clases realmente presentes en `ParaxialBeams/`
-- ejemplos recomendados hoy
-- compatibilidad MATLAB/Octave
-- forma correcta de correr tests
+- Actual repo structure
+- Classes actually present in `ParaxialBeams/`
+- Currently recommended examples
+- MATLAB/Octave compatibility
+- Correct way to run tests
 ```
 
 **Step 3: Verify docs vs repository structure**
 
-Run: comparar `README.md`, `tests/README.md`, `ParaxialBeams/` y `tests/`.
-Expected: ningún archivo documenta rutas o clases inexistentes.
+Run: compare `README.md`, `tests/README.md`, `ParaxialBeams/` and `tests/`.
+Expected: no file documents nonexistent paths or classes.
 
 **Step 4: Commit**
 
@@ -244,7 +244,7 @@ git commit -m "docs: align repository narrative with current structure"
 
 **Step 1: Capture the merge delta categories**
 
-Agregar en `plan.md` una sección `Merge Delta Summary` con estas categorías:
+Add a `Merge Delta Summary` section to `plan.md` with these categories:
 
 ```md
 - architecture
@@ -257,12 +257,12 @@ Agregar en `plan.md` una sección `Merge Delta Summary` con estas categorías:
 
 **Step 2: Evaluate merge strategy**
 
-Run: comparar claridad de `merge commit` vs `squash` para `integration/pre-master`.
-Expected: decisión explícita y rationale corto en `plan.md`.
+Run: compare clarity of `merge commit` vs `squash` for `integration/pre-master`.
+Expected: explicit decision and short rationale in `plan.md`.
 
 **Step 3: Draft the integration commit message**
 
-Agregar en `plan.md` un borrador con esta estructura:
+Add a draft to `plan.md` with this structure:
 
 ```md
 Merge `integration/pre-master`: stabilize modern beam API, portability, tests, and canonical examples
@@ -288,7 +288,7 @@ git commit -m "docs: prepare merge integration checklist"
 
 **Step 1: Create the final acceptance checklist**
 
-Agregar al final de `plan.md` esta checklist exacta:
+Add this exact checklist to the end of `plan.md`:
 
 ```md
 - [ ] merge scope frozen
@@ -302,12 +302,12 @@ Agregar al final de `plan.md` esta checklist exacta:
 
 **Step 2: Perform the final doc review**
 
-Run: leer `plan.md`, `README.md` y `tests/README.md` de punta a punta.
-Expected: los tres documentos cuentan la misma historia técnica.
+Run: read `plan.md`, `README.md`, and `tests/README.md` end-to-end.
+Expected: all three documents tell the same technical story.
 
 **Step 3: Mark unresolved items explicitly**
 
-Si algo no está listo para merge, dejarlo como unchecked y agregar nota `Blocker:` o `Deferred:` en `plan.md`.
+If something is not ready for merge, leave it unchecked and add a `Blocker:` or `Deferred:` note in `plan.md`.
 
 **Step 4: Commit**
 
@@ -323,18 +323,18 @@ git commit -m "docs: add final pre-merge readiness gate"
 
 **Step 1: Verify all readiness checks are complete**
 
-Run: revisar la checklist final de `plan.md`.
-Expected: todos los items pre-merge están completos o los blockers están explícitos.
+Run: review the final checklist in `plan.md`.
+Expected: all pre-merge items are complete or blockers are explicit.
 
 **Step 2: Merge the integration branch**
 
 Run: `git checkout master && git merge --no-ff integration/pre-master`
-Expected: merge limpio o conflictos acotados y entendibles.
+Expected: clean merge or manageable, understandable conflicts.
 
 **Step 3: Verify the merged branch still passes the portable suite**
 
 Run: `octave --no-gui --eval "run('tests/test_all.m')"`
-Expected: suite verde también después del merge.
+Expected: green suite after the merge as well.
 
 **Step 4: Commit or finalize merge message**
 
@@ -342,7 +342,7 @@ Expected: suite verde también después del merge.
 git commit
 ```
 
-Usar el mensaje preparado en la Task 6 si Git abre editor por merge commit.
+Use the message prepared in Task 6 if Git opens an editor for the merge commit.
 
 ### Task 9: Open the Post-Merge Track
 
@@ -351,19 +351,19 @@ Usar el mensaje preparado en la Task 6 si Git abre editor por merge commit.
 
 **Step 1: Create the deferred work list**
 
-Agregar en `plan.md` una sección `Post-Merge Track` con estos items:
+Add a `Post-Merge Track` section to `plan.md` with these items:
 
 ```md
-- OO cleanup: separar modelo vs cálculo
-- package migration a `+paraxial/...`
-- legacy policy para ejemplos históricos
-- application/services layer para simulaciones completas
+- OO cleanup: separate model vs computation
+- Package migration to `+paraxial/...`
+- Legacy policy for historical examples
+- Application/services layer for complete simulations
 ```
 
 **Step 2: Verify no deferred task leaked into pre-merge acceptance**
 
-Run: releer `plan.md`.
-Expected: el documento separa claramente merge readiness de evolución futura.
+Run: re-read `plan.md`.
+Expected: the document clearly separates merge readiness from future evolution.
 
 **Step 3: Commit**
 
@@ -389,26 +389,26 @@ git commit -m "docs: define post-merge redesign track"
 
 | File | Tier | Reason | Action |
 |------|------|--------|--------|
-| examples/canonical/MainGauss_refactored.m | canonical | Ejecutable, usa API moderna, bien documentado | Mantener |
-| examples/canonical/MainMultiMode.m | canonical | Multi-mode demo, usa BeamFactory | Mantener |
-| examples/canonical/ExampleRayTracing.m | canonical | Ray tracing demo completo | Mantener |
-| MainGauss.m | legacy | Old API, en examples/ por tradición | Mantener sin cambios |
-| MainHermite.m | legacy | Scripts históricos de thesis | Mantener sin cambios |
-| MainLaguerre*.m | legacy | Scripts específicos de investigación | Mantener sin cambios |
+| examples/canonical/MainGauss_refactored.m | canonical | Runnable, uses modern API, well documented | Keep |
+| examples/canonical/MainMultiMode.m | canonical | Multi-mode demo, uses BeamFactory | Keep |
+| examples/canonical/ExampleRayTracing.m | canonical | Complete ray tracing demo | Keep |
+| MainGauss.m | legacy | Old API, in examples/ by tradition | Keep unchanged |
+| MainHermite.m | legacy | Historical thesis scripts | Keep unchanged |
+| MainLaguerre*.m | legacy | Research-specific scripts | Keep unchanged |
 
 ## Critical Coverage Gates
 
-- [x] `z = 0` no produce NaN/Inf inválidos (verificado en tests)
-- [x] modo cero Hermite/Laguerre mantiene equivalencia con Gaussian (test_GaussianBeam.m)
-- [x] ray tracing cilíndrico sigue estable (test_RayTracing.m)
-- [x] `tests/test_all.m` corre vía `portable_runner()`
-- [x] el runner funciona en Octave y MATLAB (CI workflows configurados)
+- [x] `z = 0` does not produce invalid NaN/Inf (verified in tests)
+- [x] Zero-order Hermite/Laguerre maintains equivalence with Gaussian (test_GaussianBeam.m)
+- [x] Cylindrical ray tracing remains stable (test_RayTracing.m)
+- [x] `tests/test_all.m` runs via `portable_runner()`
+- [x] The runner works in both Octave and MATLAB (CI workflows configured)
 
 ## Merge Delta Summary
 
 - architecture: Strategy Pattern (IPropagator), Factory Pattern (BeamFactory), Abstract Base (ParaxialBeam)
 - tests: ~380 tests, portable_runner.m, runAllTests.m
-- ci: GitHub Actions workflows para Octave y MATLAB
+- ci: GitHub Actions workflows for Octave and MATLAB
 - portability: Octave 11.1.0+ compatible, MATLAB R2020b+ compatible
 - examples: 3 canonical, 33 legacy
 - docs: README.md, ARCHITECTURE.md, tests/README.md
@@ -417,14 +417,14 @@ git commit -m "docs: define post-merge redesign track"
 
 **Recommended: `--no-ff merge commit`**
 
-Rationale: Preserva la historia de los 71 commits de refactorización como un grupo lógico, mientras mantiene un historial lineal legible en master.
+Rationale: Preserves the history of the 71 refactoring commits as a logical group, while maintaining a readable linear history on master.
 
 ## Post-Merge Track
 
-- OO cleanup: separar modelo vs cálculo en Parameters classes
-- package migration a `+paraxial/...` namespaces
-- legacy policy: decidir qué hacer con los 33 ejemplos legacy
-- application/services layer: Wavefront, Resonator, etc.
+- OO cleanup: separate model vs computation in Parameters classes
+- Package migration to `+paraxial/...` namespaces
+- Legacy policy: decide what to do with the 33 legacy examples
+- Application/services layer: Wavefront, Resonator, etc.
 
 ---
 
@@ -438,7 +438,7 @@ Rationale: Preserva la historia de los 71 commits de refactorización como un gr
 - [x] merge strategy decided (--no-ff merge commit)
 - [x] deferred redesign work documented separately (Post-Merge Track)
 
-**Status:** ✅ READY FOR MERGE
+**Status:** READY FOR MERGE
 
 ---
 

--- a/src/beams/ElegantHermiteBeam.m
+++ b/src/beams/ElegantHermiteBeam.m
@@ -45,42 +45,27 @@ classdef ElegantHermiteBeam < ParaxialBeam
             % Legacy-compatible API:
             %   ElegantHermiteBeam(X, Y, hermiteParams)
 
-            if nargin == 0
-                obj = obj@ParaxialBeam();
-                obj.n = 0;
-                obj.m = 0;
-                obj.OpticalField = [];
-                return;
+            % Call superclass constructor first (MATLAB requirement)
+            obj = obj@ParaxialBeam();
+
+            % Determine parameters from input using static helper
+            [w0, lambda, n, m, legacyCoords, legacyZ] = ...
+                ElegantHermiteBeam.parseArgs(arg1, arg2, varargin);
+
+            % Initialize parent class state
+            if ~isempty(lambda)
+                obj.Lambda = lambda;
+                obj.k = 2 * pi / lambda;
             end
 
-            if nargin == 3 && (isa(varargin{1}, 'ElegantHermiteParameters') || isa(varargin{1}, 'HermiteParameters'))
-                params = varargin{1};
-                obj = obj@ParaxialBeam(params.Lambda);
-                obj.InitialWaist = params.InitialWaist;
-                obj.n = params.n;
-                obj.m = params.m;
-                obj.OpticalField = obj.computeField(arg1, arg2, params.zCoordinate);
-                return;
-            end
+            % Initialize subclass state
+            obj.InitialWaist = w0;
+            obj.n = n;
+            obj.m = m;
 
-            if nargin >= 2
-                w0 = arg1;
-                lambda = arg2;
-                obj = obj@ParaxialBeam(lambda);
-                obj.InitialWaist = w0;
-
-                if numel(varargin) >= 2
-                    obj.n = varargin{1};
-                    obj.m = varargin{2};
-                else
-                    obj.n = 0;
-                    obj.m = 0;
-                end
-                obj.OpticalField = [];
+            if ~isempty(legacyCoords{1})
+                obj.OpticalField = obj.computeField(legacyCoords{1}, legacyCoords{2}, legacyZ);
             else
-                obj = obj@ParaxialBeam();
-                obj.n = 0;
-                obj.m = 0;
                 obj.OpticalField = [];
             end
         end
@@ -102,6 +87,43 @@ classdef ElegantHermiteBeam < ParaxialBeam
         function name = beamName(obj)
             % beamName - Returns identifier string, e.g. 'elegant_hermite_2_0'.
             name = sprintf('elegant_hermite_%d_%d', obj.n, obj.m);
+        end
+    end
+
+    methods (Static)
+        function [w0, lambda, n, m, legacyCoords, legacyZ] = parseArgs(arg1, arg2, varargin)
+            % Static helper to parse constructor arguments
+            w0 = [];
+            lambda = [];
+            n = 0;
+            m = 0;
+            legacyCoords = {[], []};
+            legacyZ = 0;
+
+            if nargin < 2
+                return;
+            end
+
+            if nargin == 3 && (isa(varargin{1}, 'ElegantHermiteParameters') || isa(varargin{1}, 'HermiteParameters'))
+                % Legacy: ElegantHermiteBeam(X, Y, hermiteParams)
+                params = varargin{1};
+                lambda = params.Lambda;
+                w0 = params.InitialWaist;
+                n = params.n;
+                m = params.m;
+                legacyCoords{1} = arg1;
+                legacyCoords{2} = arg2;
+                legacyZ = params.zCoordinate;
+
+            elseif nargin >= 2
+                % Modern: ElegantHermiteBeam(w0, lambda, n, m)
+                w0 = arg1;
+                lambda = arg2;
+                if numel(varargin) >= 2
+                    n = varargin{1};
+                    m = varargin{2};
+                end
+            end
         end
     end
 

--- a/src/beams/ElegantHermiteBeam.m
+++ b/src/beams/ElegantHermiteBeam.m
@@ -50,7 +50,7 @@ classdef ElegantHermiteBeam < ParaxialBeam
 
             % Determine parameters from input using static helper
             [w0, lambda, n, m, legacyCoords, legacyZ] = ...
-                ElegantHermiteBeam.parseArgs(arg1, arg2, varargin);
+                ElegantHermiteBeam.parseArgs(arg1, arg2, varargin{:});
 
             % Initialize parent class state
             if ~isempty(lambda)

--- a/src/beams/ElegantLaguerreBeam.m
+++ b/src/beams/ElegantLaguerreBeam.m
@@ -48,42 +48,27 @@ classdef ElegantLaguerreBeam < ParaxialBeam
             % Legacy-compatible API:
             %   ElegantLaguerreBeam(R, Theta, laguerreParams)
 
-            if nargin == 0
-                obj = obj@ParaxialBeam();
-                obj.l = 0;
-                obj.p = 0;
-                obj.OpticalField = [];
-                return;
+            % Call superclass constructor first (MATLAB requirement)
+            obj = obj@ParaxialBeam();
+
+            % Determine parameters from input using static helper
+            [w0, lambda, l, p, legacyCoords, legacyZ] = ...
+                ElegantLaguerreBeam.parseArgs(arg1, arg2, varargin);
+
+            % Initialize parent class state
+            if ~isempty(lambda)
+                obj.Lambda = lambda;
+                obj.k = 2 * pi / lambda;
             end
 
-            if nargin == 3 && (isa(varargin{1}, 'ElegantLaguerreParameters') || isa(varargin{1}, 'LaguerreParameters'))
-                params = varargin{1};
-                obj = obj@ParaxialBeam(params.Lambda);
-                obj.InitialWaist = params.InitialWaist;
-                obj.l = params.l;
-                obj.p = params.p;
-                obj.OpticalField = obj.computeField(arg1, arg2, params.zCoordinate);
-                return;
-            end
+            % Initialize subclass state
+            obj.InitialWaist = w0;
+            obj.l = l;
+            obj.p = p;
 
-            if nargin >= 2
-                w0 = arg1;
-                lambda = arg2;
-                obj = obj@ParaxialBeam(lambda);
-                obj.InitialWaist = w0;
-
-                if numel(varargin) >= 2
-                    obj.l = varargin{1};
-                    obj.p = varargin{2};
-                else
-                    obj.l = 0;
-                    obj.p = 0;
-                end
-                obj.OpticalField = [];
+            if ~isempty(legacyCoords{1})
+                obj.OpticalField = obj.computeField(legacyCoords{1}, legacyCoords{2}, legacyZ);
             else
-                obj = obj@ParaxialBeam();
-                obj.l = 0;
-                obj.p = 0;
                 obj.OpticalField = [];
             end
         end
@@ -108,6 +93,43 @@ classdef ElegantLaguerreBeam < ParaxialBeam
         function name = beamName(obj)
             % beamName - Returns identifier string, e.g. 'elegant_laguerre_2_1'.
             name = sprintf('elegant_laguerre_%d_%d', obj.l, obj.p);
+        end
+    end
+
+    methods (Static)
+        function [w0, lambda, l, p, legacyCoords, legacyZ] = parseArgs(arg1, arg2, varargin)
+            % Static helper to parse constructor arguments
+            w0 = [];
+            lambda = [];
+            l = 0;
+            p = 0;
+            legacyCoords = {[], []};
+            legacyZ = 0;
+
+            if nargin < 2
+                return;
+            end
+
+            if nargin == 3 && (isa(varargin{1}, 'ElegantLaguerreParameters') || isa(varargin{1}, 'LaguerreParameters'))
+                % Legacy: ElegantLaguerreBeam(R, Theta, laguerreParams)
+                params = varargin{1};
+                lambda = params.Lambda;
+                w0 = params.InitialWaist;
+                l = params.l;
+                p = params.p;
+                legacyCoords{1} = arg1;
+                legacyCoords{2} = arg2;
+                legacyZ = params.zCoordinate;
+
+            elseif nargin >= 2
+                % Modern: ElegantLaguerreBeam(w0, lambda, l, p)
+                w0 = arg1;
+                lambda = arg2;
+                if numel(varargin) >= 2
+                    l = varargin{1};
+                    p = varargin{2};
+                end
+            end
         end
     end
 

--- a/src/beams/ElegantLaguerreBeam.m
+++ b/src/beams/ElegantLaguerreBeam.m
@@ -53,7 +53,7 @@ classdef ElegantLaguerreBeam < ParaxialBeam
 
             % Determine parameters from input using static helper
             [w0, lambda, l, p, legacyCoords, legacyZ] = ...
-                ElegantLaguerreBeam.parseArgs(arg1, arg2, varargin);
+                ElegantLaguerreBeam.parseArgs(arg1, arg2, varargin{:});
 
             % Initialize parent class state
             if ~isempty(lambda)

--- a/src/beams/GaussianBeam.m
+++ b/src/beams/GaussianBeam.m
@@ -30,17 +30,16 @@ classdef GaussianBeam < ParaxialBeam
             %   GaussianBeam(R, gaussianParams)
             %   GaussianBeam(X, Y, gaussianParams)
 
-            % Handle empty constructor
+            % Call superclass constructor first (MATLAB requirement - MUST be
+            % unconditional; cannot be inside a conditional or expression)
+            obj = obj@ParaxialBeam();
+
+            % Handle empty constructor — return early after minimal init
             if nargin == 0
-                obj = obj@ParaxialBeam();
                 obj.InitialWaist = [];
                 obj.OpticalField = [];
                 return;
             end
-
-            % Call superclass constructor first (MATLAB requires this to be the
-            % first statement - no code can appear before it)
-            obj = obj@ParaxialBeam();
 
             % Determine parameters from input using static helper
             [w0, lambda, legacyCoords, legacyZ] = GaussianBeam.parseArgs(arg1, arg2, varargin{:});

--- a/src/beams/GaussianBeam.m
+++ b/src/beams/GaussianBeam.m
@@ -30,36 +30,25 @@ classdef GaussianBeam < ParaxialBeam
             %   GaussianBeam(R, gaussianParams)
             %   GaussianBeam(X, Y, gaussianParams)
 
-            if nargin == 0
-                obj = obj@ParaxialBeam();
-                obj.OpticalField = [];
-                return;
+            % Call superclass constructor first (MATLAB requires this to be the
+            % first statement - no code can appear before it)
+            obj = obj@ParaxialBeam();
+
+            % Determine parameters from input using static helper
+            [w0, lambda, legacyCoords, legacyZ] = GaussianBeam.parseArgs(arg1, arg2, varargin);
+
+            % Initialize parent class state
+            if ~isempty(lambda)
+                obj.Lambda = lambda;
+                obj.k = 2 * pi / lambda;
             end
 
-            if nargin == 2 && isa(arg2, 'GaussianParameters')
-                params = arg2;
-                obj = obj@ParaxialBeam(params.Lambda);
-                obj.InitialWaist = params.InitialWaist;
-                obj.OpticalField = obj.opticalFieldLegacy(arg1, [], params.zCoordinate);
-                return;
-            end
+            % Initialize subclass state
+            obj.InitialWaist = w0;
 
-            if nargin == 3 && isa(varargin{1}, 'GaussianParameters')
-                params = varargin{1};
-                obj = obj@ParaxialBeam(params.Lambda);
-                obj.InitialWaist = params.InitialWaist;
-                obj.OpticalField = obj.opticalFieldLegacy(arg1, arg2, params.zCoordinate);
-                return;
-            end
-
-            if nargin >= 2
-                w0 = arg1;
-                lambda = arg2;
-                obj = obj@ParaxialBeam(lambda);
-                obj.InitialWaist = w0;
-                obj.OpticalField = [];
+            if ~isempty(legacyCoords{1})
+                obj.OpticalField = obj.opticalFieldLegacy(legacyCoords{1}, legacyCoords{2}, legacyZ);
             else
-                obj = obj@ParaxialBeam();
                 obj.OpticalField = [];
             end
         end
@@ -113,6 +102,44 @@ classdef GaussianBeam < ParaxialBeam
 
         function name = beamName(obj)
             name = 'gaussian';
+        end
+    end
+
+    methods (Static)
+        function [w0, lambda, legacyCoords, legacyZ] = parseArgs(arg1, arg2, varargin)
+            % Static helper to parse constructor arguments
+            % Avoids calling instance method before constructor completes
+            w0 = [];
+            lambda = [];
+            legacyCoords = {[], []};
+            legacyZ = 0;
+
+            if nargin < 2
+                return;
+            end
+
+            if nargin == 3 && isa(varargin{1}, 'GaussianParameters')
+                % GaussianBeam(X, Y, gaussianParams)
+                params = varargin{1};
+                lambda = params.Lambda;
+                w0 = params.InitialWaist;
+                legacyCoords{1} = arg1;
+                legacyCoords{2} = arg2;
+                legacyZ = params.zCoordinate;
+
+            elseif nargin == 2 && isa(arg2, 'GaussianParameters')
+                % GaussianBeam(R, gaussianParams)
+                params = arg2;
+                lambda = params.Lambda;
+                w0 = params.InitialWaist;
+                legacyCoords{1} = arg1;
+                legacyZ = params.zCoordinate;
+
+            elseif nargin >= 2
+                % Modern: GaussianBeam(w0, lambda)
+                w0 = arg1;
+                lambda = arg2;
+            end
         end
     end
 

--- a/src/beams/GaussianBeam.m
+++ b/src/beams/GaussianBeam.m
@@ -30,6 +30,14 @@ classdef GaussianBeam < ParaxialBeam
             %   GaussianBeam(R, gaussianParams)
             %   GaussianBeam(X, Y, gaussianParams)
 
+            % Handle empty constructor
+            if nargin == 0
+                obj = obj@ParaxialBeam();
+                obj.InitialWaist = [];
+                obj.OpticalField = [];
+                return;
+            end
+
             % Call superclass constructor first (MATLAB requires this to be the
             % first statement - no code can appear before it)
             obj = obj@ParaxialBeam();

--- a/src/beams/GaussianBeam.m
+++ b/src/beams/GaussianBeam.m
@@ -35,7 +35,7 @@ classdef GaussianBeam < ParaxialBeam
             obj = obj@ParaxialBeam();
 
             % Determine parameters from input using static helper
-            [w0, lambda, legacyCoords, legacyZ] = GaussianBeam.parseArgs(arg1, arg2, varargin);
+            [w0, lambda, legacyCoords, legacyZ] = GaussianBeam.parseArgs(arg1, arg2, varargin{:});
 
             % Initialize parent class state
             if ~isempty(lambda)

--- a/src/beams/HankelLaguerre.m
+++ b/src/beams/HankelLaguerre.m
@@ -43,7 +43,7 @@ classdef HankelLaguerre < ParaxialBeam
     end
 
     methods
-        function obj = HankelLaguerre(w0, lambda, l, p, hankelType)
+        function obj = HankelLaguerre(w0, lambda, l, p, hankelType, varargin)
             % Constructor
             % w0:         initial beam waist at z = 0 (m)
             % lambda:     wavelength (m)
@@ -54,29 +54,38 @@ classdef HankelLaguerre < ParaxialBeam
             % Legacy constructor (also supported):
             %   HankelLaguerre(r, theta, laguerreParameters, hankelType)
             % Produces .OpticalFieldLaguerre for legacy scripts.
+            %
+            % Note: uses varargin to capture the raw 4th argument in legacy calls,
+            % avoiding Octave parse errors when hankelType is not passed.
 
             % Call superclass constructor first (MATLAB requirement)
             obj = obj@ParaxialBeam();
 
-            % Detect legacy API before touching any arguments.
+            % Detect legacy API by checking the type of the 3rd argument.
             % Legacy: HankelLaguerre(r, theta, laguerreParams, hankelType)
-            %   — arg3 (l) is a LaguerreParameters object
+            %   — arg3 is a LaguerreParameters object
             % Modern: HankelLaguerre(w0, lambda, l, p, hankelType)
-            %   — arg3 (l) is numeric (topological charge)
-            isLegacy = (nargin >= 3 && isa(l, 'LaguerreParameters'));
+            %   — arg3 is numeric (or empty if not provided)
+            % Use inputname(3) to safely detect arg3 without Octave undefined-var errors.
+            if nargin >= 3
+                thirdArgName = inputname(3);
+                isLegacy = ~isempty(thirdArgName) && isa(l, 'LaguerreParameters');
+            else
+                isLegacy = false;
+            end
 
             if isLegacy
-                % Legacy API: save raw hankelType before applying any defaults.
-                % In legacy 4-arg form: arg4 = hankelType directly.
-                if nargin >= 4
-                    raw_hankelType_arg = hankelType;
+                % Legacy API: arg4 is hankelType (captured via varargin{1}).
+                % arg3 is LaguerreParameters (passed as 'l' in this signature).
+                if nargin >= 4 && ~isempty(varargin)
+                    raw_hankelType_arg = varargin{1};
                 else
                     raw_hankelType_arg = [];
                 end
-                % No defaults needed for l and p in legacy; they come from laguerreParams.
+                % hankelType, l, p are from the legacy call signature; set defaults for safety.
                 if nargin < 4, hankelType = 1; end
             else
-                % Modern API: apply sequential defaults for optional args.
+                % Modern API.
                 raw_hankelType_arg = [];
                 if nargin < 5, hankelType = 1; end
                 if nargin < 4, p = 0; end

--- a/src/beams/HankelLaguerre.m
+++ b/src/beams/HankelLaguerre.m
@@ -65,11 +65,11 @@ classdef HankelLaguerre < ParaxialBeam
             % Legacy: HankelLaguerre(r, theta, laguerreParams, hankelType)
             %   — arg3 is a LaguerreParameters object
             % Modern: HankelLaguerre(w0, lambda, l, p, hankelType)
-            %   — arg3 is numeric (or empty if not provided)
-            % Use inputname(3) to safely detect arg3 without Octave undefined-var errors.
-            if nargin >= 3
-                thirdArgName = inputname(3);
-                isLegacy = ~isempty(thirdArgName) && isa(l, 'LaguerreParameters');
+            %   — arg3 is numeric (topological charge) or empty
+            % Note: inputname(3) is empty when arg3 is a computed expression
+            % (e.g. LaguerreParameters(...)), so we rely on isa() directly.
+            if nargin >= 3 && isa(l, 'LaguerreParameters')
+                isLegacy = true;
             else
                 isLegacy = false;
             end
@@ -82,8 +82,8 @@ classdef HankelLaguerre < ParaxialBeam
                 else
                     raw_hankelType_arg = [];
                 end
-                % hankelType, l, p are from the legacy call signature; set defaults for safety.
-                if nargin < 4, hankelType = 1; end
+                % hankelType is the 4th positional arg in legacy calls; default to 1.
+                if nargin < 4, raw_hankelType_arg = 1; end
             else
                 % Modern API.
                 raw_hankelType_arg = [];

--- a/src/beams/HankelLaguerre.m
+++ b/src/beams/HankelLaguerre.m
@@ -58,9 +58,34 @@ classdef HankelLaguerre < ParaxialBeam
             % Call superclass constructor first (MATLAB requirement)
             obj = obj@ParaxialBeam();
 
+            % Detect legacy API before touching any arguments.
+            % Legacy: HankelLaguerre(r, theta, laguerreParams, hankelType)
+            %   — arg3 (l) is a LaguerreParameters object
+            % Modern: HankelLaguerre(w0, lambda, l, p, hankelType)
+            %   — arg3 (l) is numeric (topological charge)
+            isLegacy = (nargin >= 3 && isa(l, 'LaguerreParameters'));
+
+            if isLegacy
+                % Legacy API: save raw hankelType before applying any defaults.
+                % In legacy 4-arg form: arg4 = hankelType directly.
+                if nargin >= 4
+                    raw_hankelType_arg = hankelType;
+                else
+                    raw_hankelType_arg = [];
+                end
+                % No defaults needed for l and p in legacy; they come from laguerreParams.
+                if nargin < 4, hankelType = 1; end
+            else
+                % Modern API: apply sequential defaults for optional args.
+                raw_hankelType_arg = [];
+                if nargin < 5, hankelType = 1; end
+                if nargin < 4, p = 0; end
+                if nargin < 3, l = 0; end
+            end
+
             % Determine parameters from input using static helper
             [w0_out, lambda_out, l_out, p_out, hankelType_out, legacyCoords, legacyZ] = ...
-                HankelLaguerre.parseArgs(w0, lambda, l, p, hankelType);
+                HankelLaguerre.parseArgs(w0, lambda, l, p, hankelType, raw_hankelType_arg);
 
             % Initialize parent class state
             if ~isempty(lambda_out)
@@ -106,9 +131,10 @@ classdef HankelLaguerre < ParaxialBeam
     end
 
     methods (Static)
-        function [w0, lambda, l, p, hankelType, legacyCoords, legacyZ] = parseArgs(w0, lambda, l, p, hankelType)
+        function [w0, lambda, l, p, hankelType, legacyCoords, legacyZ] = parseArgs(w0, lambda, l, p, hankelType, raw_hankelType_arg)
             % Static helper to parse constructor arguments
             % Detects legacy API: when l is a LaguerreParameters object
+            if nargin < 6, raw_hankelType_arg = []; end
             w0_out = w0;
             lambda_out = lambda;
             l_out = 0;
@@ -132,8 +158,10 @@ classdef HankelLaguerre < ParaxialBeam
                 lambda_out = laguerreParams.Lambda;
                 l_out = laguerreParams.l;
                 p_out = laguerreParams.p;
-                if nargin >= 4
-                    hankelType_out = p;
+                % raw_hankelType_arg is the 4th arg when provided in the legacy call.
+                % If non-empty, it is the actual hankelType value (not a LaguerreParameters).
+                if ~isempty(raw_hankelType_arg)
+                    hankelType_out = raw_hankelType_arg;
                 else
                     hankelType_out = 1; % default when not provided
                 end

--- a/src/beams/HankelLaguerre.m
+++ b/src/beams/HankelLaguerre.m
@@ -144,47 +144,34 @@ classdef HankelLaguerre < ParaxialBeam
             % Static helper to parse constructor arguments
             % Detects legacy API: when l is a LaguerreParameters object
             if nargin < 6, raw_hankelType_arg = []; end
-            w0_out = w0;
-            lambda_out = lambda;
-            l_out = 0;
-            p_out = 0;
-            hankelType_out = 1;
             legacyCoords = {[], []};
             legacyZ = 0;
 
             if nargin < 1
+                l = 0; p = 0; hankelType = 1;
                 return;
             end
 
             % Legacy path: HankelLaguerre(r, theta, laguerreParams, hankelType)
             if nargin >= 3 && isa(l, 'LaguerreParameters')
-                % l is actually laguerreParams
                 laguerreParams = l;
                 legacyCoords{1} = w0;      % r coordinate
                 legacyCoords{2} = lambda;  % theta coordinate
                 legacyZ = laguerreParams.zCoordinate;
-                w0_out = laguerreParams.InitialWaist;
-                lambda_out = laguerreParams.Lambda;
-                l_out = laguerreParams.l;
-                p_out = laguerreParams.p;
-                % raw_hankelType_arg is the 4th arg when provided in the legacy call.
-                % If non-empty, it is the actual hankelType value (not a LaguerreParameters).
+                w0 = laguerreParams.InitialWaist;
+                lambda = laguerreParams.Lambda;
+                l = laguerreParams.l;
+                p = laguerreParams.p;
                 if ~isempty(raw_hankelType_arg)
-                    hankelType_out = raw_hankelType_arg;
+                    hankelType = raw_hankelType_arg;
                 else
-                    hankelType_out = 1; % default when not provided
+                    hankelType = 1;
                 end
             else
                 % Modern path: HankelLaguerre(w0, lambda, l, p, hankelType)
-                if nargin >= 3
-                    l_out = l;
-                end
-                if nargin >= 4
-                    p_out = p;
-                end
-                if nargin >= 5
-                    hankelType_out = hankelType;
-                end
+                if nargin < 3, l = 0; end
+                if nargin < 4, p = 0; end
+                if nargin < 5, hankelType = 1; end
             end
         end
 

--- a/src/beams/HankelLaguerre.m
+++ b/src/beams/HankelLaguerre.m
@@ -55,42 +55,29 @@ classdef HankelLaguerre < ParaxialBeam
             %   HankelLaguerre(r, theta, laguerreParameters, hankelType)
             % Produces .OpticalFieldLaguerre for legacy scripts.
 
-            if nargin > 0
-                if nargin >= 4 && isa(l, 'LaguerreParameters')
-                    rCoordinate = w0;
-                    thetaCoordinate = lambda;
-                    laguerreParams = l;
-                    obj = obj@ParaxialBeam(laguerreParams.Lambda);
-                    obj.InitialWaist = laguerreParams.InitialWaist;
-                    obj.l = laguerreParams.l;
-                    obj.p = laguerreParams.p;
-                    obj.HankelType = p;
-                    obj.OpticalFieldLaguerre = hankelField(rCoordinate, thetaCoordinate, ...
-                                                           laguerreParams.InitialWaist, laguerreParams.Lambda, ...
-                                                           laguerreParams.l, laguerreParams.p, ...
-                                                           laguerreParams.zCoordinate, obj.HankelType);
-                else
-                    obj = obj@ParaxialBeam(lambda);
-                    obj.InitialWaist = w0;
-                    if nargin >= 4
-                        obj.l = l;
-                        obj.p = p;
-                    else
-                        obj.l = 0;
-                        obj.p = 0;
-                    end
-                    if nargin >= 5
-                        obj.HankelType = hankelType;
-                    else
-                        obj.HankelType = 1;
-                    end
-                    obj.OpticalFieldLaguerre = [];
-                end
+            % Call superclass constructor first (MATLAB requirement)
+            obj = obj@ParaxialBeam();
+
+            % Determine parameters from input using static helper
+            [w0_out, lambda_out, l_out, p_out, hankelType_out, legacyCoords, legacyZ] = ...
+                HankelLaguerre.parseArgs(w0, lambda, l, p, hankelType);
+
+            % Initialize parent class state
+            if ~isempty(lambda_out)
+                obj.Lambda = lambda_out;
+                obj.k = 2 * pi / lambda_out;
+            end
+
+            % Initialize subclass state
+            obj.InitialWaist = w0_out;
+            obj.l = l_out;
+            obj.p = p_out;
+            obj.HankelType = hankelType_out;
+
+            if ~isempty(legacyCoords{1})
+                obj.OpticalFieldLaguerre = hankelField(legacyCoords{1}, legacyCoords{2}, ...
+                    w0_out, lambda_out, l_out, p_out, legacyZ, hankelType_out);
             else
-                obj = obj@ParaxialBeam();
-                obj.l          = 0;
-                obj.p          = 0;
-                obj.HankelType = 1;
                 obj.OpticalFieldLaguerre = [];
             end
         end
@@ -119,6 +106,49 @@ classdef HankelLaguerre < ParaxialBeam
     end
 
     methods (Static)
+        function [w0, lambda, l, p, hankelType, legacyCoords, legacyZ] = parseArgs(w0, lambda, l, p, hankelType)
+            % Static helper to parse constructor arguments
+            % Detects legacy API: when l is a LaguerreParameters object
+            w0_out = w0;
+            lambda_out = lambda;
+            l_out = 0;
+            p_out = 0;
+            hankelType_out = 1;
+            legacyCoords = {[], []};
+            legacyZ = 0;
+
+            if nargin < 1
+                return;
+            end
+
+            % Legacy path: HankelLaguerre(r, theta, laguerreParams, hankelType)
+            if nargin >= 3 && isa(l, 'LaguerreParameters')
+                % l is actually laguerreParams
+                laguerreParams = l;
+                legacyCoords{1} = w0;      % r coordinate
+                legacyCoords{2} = lambda;  % theta coordinate
+                legacyZ = laguerreParams.zCoordinate;
+                w0_out = laguerreParams.InitialWaist;
+                lambda_out = laguerreParams.Lambda;
+                l_out = laguerreParams.l;
+                p_out = laguerreParams.p;
+                if nargin >= 4
+                    hankelType_out = p;
+                end
+            else
+                % Modern path: HankelLaguerre(w0, lambda, l, p, hankelType)
+                if nargin >= 3
+                    l_out = l;
+                end
+                if nargin >= 4
+                    p_out = p;
+                end
+                if nargin >= 5
+                    hankelType_out = hankelType;
+                end
+            end
+        end
+
         function Rays = getPropagateCylindricalRays(Rays, TotalRays, r, th, difr, LParametersZi, LParametersZ, HankelType)
             % getPropagateCylindricalRays - Legacy-compatible ray propagation API.
             tempdr = num2cell(difr);

--- a/src/beams/HankelLaguerre.m
+++ b/src/beams/HankelLaguerre.m
@@ -75,15 +75,15 @@ classdef HankelLaguerre < ParaxialBeam
             end
 
             if isLegacy
-                % Legacy API: arg4 is hankelType (captured via varargin{1}).
-                % arg3 is LaguerreParameters (passed as 'l' in this signature).
-                if nargin >= 4 && ~isempty(varargin)
-                    raw_hankelType_arg = varargin{1};
+                % Legacy API: HankelLaguerre(r, theta, laguerreParams, hankelType)
+                % The 4th legacy arg maps to 'p' in this signature (not varargin).
+                if nargin >= 4
+                    raw_hankelType_arg = p;
                 else
-                    raw_hankelType_arg = [];
+                    raw_hankelType_arg = 1;
                 end
-                % hankelType is the 4th positional arg in legacy calls; default to 1.
-                if nargin < 4, raw_hankelType_arg = 1; end
+                % parseArgs expects hankelType defined; set from extracted value.
+                hankelType = raw_hankelType_arg;
             else
                 % Modern API.
                 raw_hankelType_arg = [];

--- a/src/beams/HankelLaguerre.m
+++ b/src/beams/HankelLaguerre.m
@@ -134,6 +134,8 @@ classdef HankelLaguerre < ParaxialBeam
                 p_out = laguerreParams.p;
                 if nargin >= 4
                     hankelType_out = p;
+                else
+                    hankelType_out = 1; % default when not provided
                 end
             else
                 % Modern path: HankelLaguerre(w0, lambda, l, p, hankelType)

--- a/src/beams/HermiteBeam.m
+++ b/src/beams/HermiteBeam.m
@@ -42,42 +42,27 @@ classdef HermiteBeam < ParaxialBeam
             % Legacy-compatible API:
             %   HermiteBeam(X, Y, hermiteParams)
 
-            if nargin == 0
-                obj = obj@ParaxialBeam();
-                obj.n = 0;
-                obj.m = 0;
-                obj.OpticalField = [];
-                return;
+            % Call superclass constructor first (MATLAB requirement)
+            obj = obj@ParaxialBeam();
+
+            % Determine parameters from input using static helper
+            [w0, lambda, n, m, legacyCoords, legacyZ] = ...
+                HermiteBeam.parseArgs(arg1, arg2, varargin);
+
+            % Initialize parent class state
+            if ~isempty(lambda)
+                obj.Lambda = lambda;
+                obj.k = 2 * pi / lambda;
             end
 
-            if nargin == 3 && isa(varargin{1}, 'HermiteParameters')
-                params = varargin{1};
-                obj = obj@ParaxialBeam(params.Lambda);
-                obj.InitialWaist = params.InitialWaist;
-                obj.n = params.n;
-                obj.m = params.m;
-                obj.OpticalField = obj.computeField(arg1, arg2, params.zCoordinate);
-                return;
-            end
+            % Initialize subclass state
+            obj.InitialWaist = w0;
+            obj.n = n;
+            obj.m = m;
 
-            if nargin >= 2
-                w0 = arg1;
-                lambda = arg2;
-                obj = obj@ParaxialBeam(lambda);
-                obj.InitialWaist = w0;
-
-                if numel(varargin) >= 2
-                    obj.n = varargin{1};
-                    obj.m = varargin{2};
-                else
-                    obj.n = 0;
-                    obj.m = 0;
-                end
-                obj.OpticalField = [];
+            if ~isempty(legacyCoords{1})
+                obj.OpticalField = obj.computeField(legacyCoords{1}, legacyCoords{2}, legacyZ);
             else
-                obj = obj@ParaxialBeam();
-                obj.n = 0;
-                obj.m = 0;
                 obj.OpticalField = [];
             end
         end
@@ -99,6 +84,43 @@ classdef HermiteBeam < ParaxialBeam
         function name = beamName(obj)
             % beamName - Returns identifier string, e.g. 'hermite_3_2'.
             name = sprintf('hermite_%d_%d', obj.n, obj.m);
+        end
+    end
+
+    methods (Static)
+        function [w0, lambda, n, m, legacyCoords, legacyZ] = parseArgs(arg1, arg2, varargin)
+            % Static helper to parse constructor arguments
+            w0 = [];
+            lambda = [];
+            n = 0;
+            m = 0;
+            legacyCoords = {[], []};
+            legacyZ = 0;
+
+            if nargin < 2
+                return;
+            end
+
+            if nargin == 3 && isa(varargin{1}, 'HermiteParameters')
+                % Legacy: HermiteBeam(X, Y, hermiteParams)
+                params = varargin{1};
+                lambda = params.Lambda;
+                w0 = params.InitialWaist;
+                n = params.n;
+                m = params.m;
+                legacyCoords{1} = arg1;
+                legacyCoords{2} = arg2;
+                legacyZ = params.zCoordinate;
+
+            elseif nargin >= 2
+                % Modern: HermiteBeam(w0, lambda, n, m)
+                w0 = arg1;
+                lambda = arg2;
+                if numel(varargin) >= 2
+                    n = varargin{1};
+                    m = varargin{2};
+                end
+            end
         end
     end
 

--- a/src/beams/HermiteBeam.m
+++ b/src/beams/HermiteBeam.m
@@ -47,7 +47,7 @@ classdef HermiteBeam < ParaxialBeam
 
             % Determine parameters from input using static helper
             [w0, lambda, n, m, legacyCoords, legacyZ] = ...
-                HermiteBeam.parseArgs(arg1, arg2, varargin);
+                HermiteBeam.parseArgs(arg1, arg2, varargin{:});
 
             % Initialize parent class state
             if ~isempty(lambda)

--- a/src/beams/LaguerreBeam.m
+++ b/src/beams/LaguerreBeam.m
@@ -44,42 +44,27 @@ classdef LaguerreBeam < ParaxialBeam
             % Legacy-compatible API:
             %   LaguerreBeam(R, Theta, laguerreParams)
 
-            if nargin == 0
-                obj = obj@ParaxialBeam();
-                obj.l = 0;
-                obj.p = 0;
-                obj.OpticalField = [];
-                return;
+            % Call superclass constructor first (MATLAB requirement)
+            obj = obj@ParaxialBeam();
+
+            % Determine parameters from input using static helper
+            [w0, lambda, l, p, legacyCoords, legacyZ] = ...
+                LaguerreBeam.parseArgs(arg1, arg2, varargin);
+
+            % Initialize parent class state
+            if ~isempty(lambda)
+                obj.Lambda = lambda;
+                obj.k = 2 * pi / lambda;
             end
 
-            if nargin == 3 && isa(varargin{1}, 'LaguerreParameters')
-                params = varargin{1};
-                obj = obj@ParaxialBeam(params.Lambda);
-                obj.InitialWaist = params.InitialWaist;
-                obj.l = params.l;
-                obj.p = params.p;
-                obj.OpticalField = obj.computeField(arg1, arg2, params.zCoordinate);
-                return;
-            end
+            % Initialize subclass state
+            obj.InitialWaist = w0;
+            obj.l = l;
+            obj.p = p;
 
-            if nargin >= 2
-                w0 = arg1;
-                lambda = arg2;
-                obj = obj@ParaxialBeam(lambda);
-                obj.InitialWaist = w0;
-
-                if numel(varargin) >= 2
-                    obj.l = varargin{1};
-                    obj.p = varargin{2};
-                else
-                    obj.l = 0;
-                    obj.p = 0;
-                end
-                obj.OpticalField = [];
+            if ~isempty(legacyCoords{1})
+                obj.OpticalField = obj.computeField(legacyCoords{1}, legacyCoords{2}, legacyZ);
             else
-                obj = obj@ParaxialBeam();
-                obj.l = 0;
-                obj.p = 0;
                 obj.OpticalField = [];
             end
         end
@@ -104,6 +89,43 @@ classdef LaguerreBeam < ParaxialBeam
         function name = beamName(obj)
             % beamName - Returns identifier string, e.g. 'laguerre_2_1'.
             name = sprintf('laguerre_%d_%d', obj.l, obj.p);
+        end
+    end
+
+    methods (Static)
+        function [w0, lambda, l, p, legacyCoords, legacyZ] = parseArgs(arg1, arg2, varargin)
+            % Static helper to parse constructor arguments
+            w0 = [];
+            lambda = [];
+            l = 0;
+            p = 0;
+            legacyCoords = {[], []};
+            legacyZ = 0;
+
+            if nargin < 2
+                return;
+            end
+
+            if nargin == 3 && isa(varargin{1}, 'LaguerreParameters')
+                % Legacy: LaguerreBeam(R, Theta, laguerreParams)
+                params = varargin{1};
+                lambda = params.Lambda;
+                w0 = params.InitialWaist;
+                l = params.l;
+                p = params.p;
+                legacyCoords{1} = arg1;
+                legacyCoords{2} = arg2;
+                legacyZ = params.zCoordinate;
+
+            elseif nargin >= 2
+                % Modern: LaguerreBeam(w0, lambda, l, p)
+                w0 = arg1;
+                lambda = arg2;
+                if numel(varargin) >= 2
+                    l = varargin{1};
+                    p = varargin{2};
+                end
+            end
         end
     end
 

--- a/src/beams/LaguerreBeam.m
+++ b/src/beams/LaguerreBeam.m
@@ -49,7 +49,7 @@ classdef LaguerreBeam < ParaxialBeam
 
             % Determine parameters from input using static helper
             [w0, lambda, l, p, legacyCoords, legacyZ] = ...
-                LaguerreBeam.parseArgs(arg1, arg2, varargin);
+                LaguerreBeam.parseArgs(arg1, arg2, varargin{:});
 
             % Initialize parent class state
             if ~isempty(lambda)

--- a/tests/modern/test_ElegantHermiteBeam.m
+++ b/tests/modern/test_ElegantHermiteBeam.m
@@ -16,7 +16,7 @@ ehb = ElegantHermiteBeam(w0, lambda, 1, 1);
 
 % testFieldGeneration
 field = ehb.opticalField(X, Y, 0.01);
-if (size(field) == [64, 64])
+if (isequal(size(field), [64, 64]))
     fprintf('  PASS: field generation\n');
     passed = passed + 1;
 else

--- a/tests/modern/test_ElegantLaguerreBeam.m
+++ b/tests/modern/test_ElegantLaguerreBeam.m
@@ -16,7 +16,7 @@ elb = ElegantLaguerreBeam(w0, lambda, 1, 0);
 
 % testFieldGeneration
 field = elb.opticalField(X, Y, 0.01);
-if (size(field) == [64, 64])
+if (isequal(size(field), [64, 64]))
     fprintf('  PASS: field generation\n');
     passed = passed + 1;
 else
@@ -97,7 +97,7 @@ elb_10 = ElegantLaguerreBeam(w0, lambda, 1, 0);
 elb_01 = ElegantLaguerreBeam(w0, lambda, 0, 1);
 f_10 = elb_10.opticalField(X, Y, 0.01);
 f_01 = elb_01.opticalField(X, Y, 0.01);
-if (size(f_10) == size(f_01))
+if (isequal(size(f_10), size(f_01)))
     fprintf('  PASS: different l p valid\n');
     passed = passed + 1;
 else

--- a/tests/modern/test_FFTUtils.m
+++ b/tests/modern/test_FFTUtils.m
@@ -186,7 +186,7 @@ end
 
 % test fft2_centered output size
 G_cc = FFTUtils.fft2_centered(g);
-if (size(G_cc) == size(g))
+if (isequal(size(G_cc), size(g)))
     fprintf('  PASS: fft2_centered size\n');
     passed = passed + 1;
 else

--- a/tests/modern/test_GaussianBeam.m
+++ b/tests/modern/test_GaussianBeam.m
@@ -16,7 +16,7 @@ beam = GaussianBeam(w0, lambda);
 
 % testFieldGeneration
 field = beam.opticalField(X, Y, 0.01);
-if (size(field) == [64, 64])
+if (isequal(size(field), [64, 64]))
     fprintf('  PASS: field generation\n');
     passed = passed + 1;
 else

--- a/tests/modern/test_GridUtils.m
+++ b/tests/modern/test_GridUtils.m
@@ -22,7 +22,7 @@ end
 
 % testCreateFreqGrid
 [Kx, Ky] = grid.createFreqGrid();
-if (size(Kx) == [Nx, Nx])
+if (isequal(size(Kx), [Nx, Nx]))
     fprintf('  PASS: createFreqGrid\n');
     passed = passed + 1;
 else
@@ -32,7 +32,7 @@ end
 
 % testMeshgrid2D
 [Xm, Ym] = GridUtils.meshgrid2D(32, 1e-3);
-if (size(Xm) == [32, 32])
+if (isequal(size(Xm), [32, 32]))
     fprintf('  PASS: meshgrid2D\n');
     passed = passed + 1;
 else
@@ -42,7 +42,7 @@ end
 
 % testFreqGrid
 [Kxf, Kyf] = GridUtils.freqGrid(32, 1e-3);
-if (size(Kxf) == [32, 32])
+if (isequal(size(Kxf), [32, 32]))
     fprintf('  PASS: freqGrid\n');
     passed = passed + 1;
 else
@@ -52,7 +52,7 @@ end
 
 % testPolarGrid
 [r, theta] = GridUtils.polarGrid(32, 1e-3);
-if (size(r) == [32, 32])
+if (isequal(size(r), [32, 32]))
     fprintf('  PASS: polarGrid\n');
     passed = passed + 1;
 else
@@ -175,7 +175,7 @@ end
 
 % testMeshgrid2DStaticValues
 [Xms, Yms] = GridUtils.meshgrid2D(4, 1e-3);
-if (size(Xms) == [4, 4] && size(Yms) == [4, 4])
+if (isequal(size(Xms), [4, 4]) && isequal(size(Yms), [4, 4]))
     fprintf('  PASS: meshgrid2D static\n');
     passed = passed + 1;
 else
@@ -248,7 +248,7 @@ end
 
 % testStaticMeshgrid2DDifferentN
 [Xmd, Ymd] = GridUtils.meshgrid2D(16, 2e-3);
-if (size(Xmd) == [16, 16])
+if (isequal(size(Xmd), [16, 16]))
     fprintf('  PASS: meshgrid2D different N\n');
     passed = passed + 1;
 else
@@ -258,7 +258,7 @@ end
 
 % testStaticFreqGridDifferentN
 [Kxd, Kyd] = GridUtils.freqGrid(16, 2e-3);
-if (size(Kxd) == [16, 16])
+if (isequal(size(Kxd), [16, 16]))
     fprintf('  PASS: freqGrid different N\n');
     passed = passed + 1;
 else

--- a/tests/modern/test_HankelLaguerre.m
+++ b/tests/modern/test_HankelLaguerre.m
@@ -26,7 +26,7 @@ end
 % testConstructorHankelType2
 HL2 = HankelLaguerre(w0, lambda, 1, 0, 2);
 field2 = HL2.opticalField(X, Y, 0);
-if (~isempty(field2) && size(field2) == [64, 64])
+if (~isempty(field2) && isequal(size(field2), [64, 64]))
     fprintf('  PASS: constructor hankelType=2\n');
     passed = passed + 1;
 else

--- a/tests/modern/test_HermiteBeam.m
+++ b/tests/modern/test_HermiteBeam.m
@@ -16,7 +16,7 @@ hb = HermiteBeam(w0, lambda, 1, 1);
 
 % testFieldGeneration
 field = hb.opticalField(X, Y, 0);
-if (size(field) == [64, 64])
+if (isequal(size(field), [64, 64]))
     fprintf('  PASS: field generation\n');
     passed = passed + 1;
 else
@@ -83,7 +83,7 @@ hb_10 = HermiteBeam(w0, lambda, 1, 0);
 hb_01 = HermiteBeam(w0, lambda, 0, 1);
 field_10 = hb_10.opticalField(X, Y, 0);
 field_01 = hb_01.opticalField(X, Y, 0);
-if (size(field_10) == size(field_01))
+if (isequal(size(field_10), size(field_01)))
     fprintf('  PASS: different orders valid\n');
     passed = passed + 1;
 else
@@ -138,7 +138,7 @@ end
 % testHermitePolyMatrixInput
 x_mat = rand(5, 5);
 H_mat = PolynomialUtils.hermitePoly(2, x_mat);
-if (size(H_mat) == size(x_mat))
+if (isequal(size(H_mat), size(x_mat)))
     fprintf('  PASS: hermitePoly matrix input\n');
     passed = passed + 1;
 else

--- a/tests/modern/test_LaguerreBeam.m
+++ b/tests/modern/test_LaguerreBeam.m
@@ -16,7 +16,7 @@ lb = LaguerreBeam(w0, lambda, 1, 0);
 
 % testFieldGeneration
 field = lb.opticalField(X, Y, 0);
-if (size(field) == [64, 64])
+if (isequal(size(field), [64, 64]))
     fprintf('  PASS: field generation\n');
     passed = passed + 1;
 else
@@ -69,7 +69,7 @@ lb_10 = LaguerreBeam(w0, lambda, 1, 0);
 lb_01 = LaguerreBeam(w0, lambda, 0, 1);
 field_10 = lb_10.opticalField(X, Y, 0);
 field_01 = lb_01.opticalField(X, Y, 0);
-if (size(field_10) == size(field_01))
+if (isequal(size(field_10), size(field_01)))
     fprintf('  PASS: different l p valid\n');
     passed = passed + 1;
 else
@@ -80,7 +80,7 @@ end
 % testL0P0Valid
 lb_00 = LaguerreBeam(w0, lambda, 0, 0);
 field_00 = lb_00.opticalField(X, Y, 0);
-if (size(field_00) == [64, 64])
+if (isequal(size(field_00), [64, 64]))
     fprintf('  PASS: l=0 p=0 valid\n');
     passed = passed + 1;
 else

--- a/tests/modern/test_PhysicalConstants.m
+++ b/tests/modern/test_PhysicalConstants.m
@@ -335,7 +335,7 @@ end
 % testWaveNumberMatrixInput
 lambda_mat = [532e-9 633e-9; 1064e-9 1550e-9];
 k_mat = PhysicalConstants.waveNumber(lambda_mat);
-if (all(all(k_mat > 0)) && size(k_mat) == size(lambda_mat))
+if (all(all(k_mat > 0)) && isequal(size(k_mat), size(lambda_mat)))
     fprintf('  PASS: waveNumber matrix input\n');
     passed = passed + 1;
 else

--- a/tests/modern/test_Propagators.m
+++ b/tests/modern/test_Propagators.m
@@ -28,7 +28,7 @@ end
 
 % testAnalyticPropagateSize
 field = ap.propagate(beam, 0.1);
-if (size(field) == [64, 64])
+if (isequal(size(field), [64, 64]))
     fprintf('  PASS: AnalyticPropagator field size\n');
     passed = passed + 1;
 else
@@ -69,7 +69,7 @@ end
 % testAnalyticWithHermiteBeam
 hb = HermiteBeam(w0, lambda, 1, 1);
 field_h = ap.propagate(hb, 0.05);
-if (all(all(isfinite(field_h))) && size(field_h) == [64, 64])
+if (all(all(isfinite(field_h))) && isequal(size(field_h), [64, 64]))
     fprintf('  PASS: AnalyticPropagator with HermiteBeam\n');
     passed = passed + 1;
 else
@@ -80,7 +80,7 @@ end
 % testAnalyticWithLaguerreBeam
 lb = LaguerreBeam(w0, lambda, 1, 0);
 field_l = ap.propagate(lb, 0.05);
-if (all(all(isfinite(field_l))) && size(field_l) == [64, 64])
+if (all(all(isfinite(field_l))) && isequal(size(field_l), [64, 64]))
     fprintf('  PASS: AnalyticPropagator with LaguerreBeam\n');
     passed = passed + 1;
 else
@@ -114,7 +114,7 @@ end
 
 % testFFTPropagateSize
 field_fft = fp.propagate(beam, 0.1);
-if (size(field_fft) == [64, 64])
+if (isequal(size(field_fft), [64, 64]))
     fprintf('  PASS: FFTPropagator field size\n');
     passed = passed + 1;
 else
@@ -179,7 +179,7 @@ end
 
 % testFFTWithHermiteBeam
 field_fft_h = fp.propagate(HermiteBeam(w0, lambda, 1, 1), 0.05);
-if (all(all(isfinite(field_fft_h))) && size(field_fft_h) == [64, 64])
+if (all(all(isfinite(field_fft_h))) && isequal(size(field_fft_h), [64, 64]))
     fprintf('  PASS: FFTPropagator with HermiteBeam\n');
     passed = passed + 1;
 else

--- a/tests/modern/test_RayTracing.m
+++ b/tests/modern/test_RayTracing.m
@@ -13,7 +13,7 @@ failed = 0;
 
 % testRayBundleGridInitialization
 bundle_grid = RayBundle.createGrid(10, 12, 1e-3, 1.2e-3);
-if (isequal(size(bundle_grid.x), [12, 10, 1]) && abs(max(bundle_grid.x(:)) - 0.5e-3) < 1e-8)
+if (size(bundle_grid.x, 1) == 12 && size(bundle_grid.x, 2) == 10 && size(bundle_grid.x, 3) == 1 && abs(max(bundle_grid.x(:)) - 0.5e-3) < 1e-8)
     fprintf('  PASS: RayBundle createGrid initialization\n');
     passed = passed + 1;
 else

--- a/tests/modern/test_RayTracing.m
+++ b/tests/modern/test_RayTracing.m
@@ -1,55 +1,95 @@
-classdef test_RayTracing
-    % Unit tests for Ray Tracing integration
-    
-    methods
-        function testRayBundleInitialization(obj, testCase)
-            % Test grid creation
-            bundle = RayBundle.createGrid(10, 12, 1e-3, 1.2e-3);
-            testCase.verifySize(bundle.x, [12, 10]);
-            testCase.verifyEqual(max(bundle.x(:)), 0.5e-3, 'RelTol', 1e-5);
-            
-            % Test concentric creation
-            bundle = RayBundle.createConcentric(5, 8, 1e-3);
-            testCase.verifyEqual(bundle.Nx, 5);
-            testCase.verifyEqual(bundle.Ny, 8);
-        end
-        
-        function testRayTracerSlopes(obj, testCase)
-            % Test slope calculation for a Gaussian beam
-            lambda = 632.8e-9;
-            w0 = 100e-6;
-            params = GaussianParameters(0, w0, lambda);
-            beam = GaussianBeam(0, params);
-            
-            % At z=0, the phase of a Gaussian beam is flat (m=0)
-            [sx, sy] = RayTracer.calculateSlopes(beam, 0, 0, 0);
-            testCase.verifyEqual(sx, 0, 'AbsTol', 1e-10);
-            testCase.verifyEqual(sy, 0, 'AbsTol', 1e-10);
-            
-            % Off-center at z=0 should also be 0 in paraxial approx if tilted=false
-            [sx, sy] = RayTracer.calculateSlopes(beam, 50e-6, 0, 0);
-            testCase.verifyEqual(sx, 0, 'AbsTol', 1e-6);
-        end
-        
-        function testPropagationFreeSpace(obj, testCase)
-            % Test Euler and RK4 for a Gaussian beam
-            lambda = 632.8e-9;
-            w0 = 100e-6;
-            params = GaussianParameters(0, w0, lambda);
-            beam = GaussianBeam(0, params);
-            zr = pi * w0^2 / lambda;
-            
-            bundle = RayBundle.createGrid(5, 5, 200e-6, 200e-6);
-            
-            % Propagate to Rayleigh distance
-            dz = zr / 10;
-            RayTracer.propagate(bundle, beam, zr, dz, 'RK4');
-            
-            % Rays should diverge
-            testCase.verifyGreaterThan(bundle.Nz, 1);
-            last_x = bundle.x(1, end, end);
-            first_x = bundle.x(1, end, 1);
-            testCase.verifyGreaterThan(abs(last_x), abs(first_x));
-        end
-    end
+% Compatible with GNU Octave and MATLAB
+% Tests for Ray tracing integration (script-style for portable runner)
+
+addpath(fullfile(fileparts(fileparts(fileparts(mfilename('fullpath')))), 'ParaxialBeams'));
+
+fprintf('=== RayTracing Tests ===\n\n');
+passed = 0;
+failed = 0;
+
+% -----------------------------------------------------------------
+% RayBundle initialization
+% -----------------------------------------------------------------
+
+% testRayBundleGridInitialization
+bundle_grid = RayBundle.createGrid(10, 12, 1e-3, 1.2e-3);
+if (isequal(size(bundle_grid.x), [12, 10, 1]) && abs(max(bundle_grid.x(:)) - 0.5e-3) < 1e-8)
+    fprintf('  PASS: RayBundle createGrid initialization\n');
+    passed = passed + 1;
+else
+    fprintf('  FAIL: RayBundle createGrid initialization\n');
+    failed = failed + 1;
+end
+
+% testRayBundleConcentricInitialization
+bundle_conc = RayBundle.createConcentric(5, 8, 1e-3);
+if (bundle_conc.Nx == 5 && bundle_conc.Ny == 8)
+    fprintf('  PASS: RayBundle createConcentric initialization\n');
+    passed = passed + 1;
+else
+    fprintf('  FAIL: RayBundle createConcentric initialization\n');
+    failed = failed + 1;
+end
+
+% -----------------------------------------------------------------
+% RayTracer slope calculations
+% -----------------------------------------------------------------
+
+lambda = 632.8e-9;
+w0 = 100e-6;
+beam = GaussianBeam(w0, lambda);
+
+% testRayTracerSlopesAtCenter
+[sx0, sy0] = RayTracer.calculateSlopes(beam, 0, 0, 0);
+if (abs(sx0) < 1e-10 && abs(sy0) < 1e-10)
+    fprintf('  PASS: RayTracer slopes at center\n');
+    passed = passed + 1;
+else
+    fprintf('  FAIL: RayTracer slopes at center\n');
+    failed = failed + 1;
+end
+
+% testRayTracerSlopesOffCenterAtZ0
+[sx1, sy1] = RayTracer.calculateSlopes(beam, 50e-6, 0, 0);
+if (abs(sx1) < 1e-6 && abs(sy1) < 1e-6)
+    fprintf('  PASS: RayTracer slopes off-center at z=0\n');
+    passed = passed + 1;
+else
+    fprintf('  FAIL: RayTracer slopes off-center at z=0\n');
+    failed = failed + 1;
+end
+
+% -----------------------------------------------------------------
+% Free-space propagation
+% -----------------------------------------------------------------
+
+zr = pi * w0^2 / lambda;
+bundle_prop = RayBundle.createGrid(5, 5, 200e-6, 200e-6);
+dz = zr / 10;
+bundle_prop = RayTracer.propagate(bundle_prop, beam, zr, dz, 'RK4');
+
+% testPropagationAddsSteps
+if (bundle_prop.Nz > 1)
+    fprintf('  PASS: RayTracer propagation adds z steps\n');
+    passed = passed + 1;
+else
+    fprintf('  FAIL: RayTracer propagation adds z steps\n');
+    failed = failed + 1;
+end
+
+% testPropagationDivergence
+last_x = bundle_prop.x(1, end, end);
+first_x = bundle_prop.x(1, end, 1);
+if (abs(last_x) > abs(first_x))
+    fprintf('  PASS: RayTracer propagation diverges rays\n');
+    passed = passed + 1;
+else
+    fprintf('  FAIL: RayTracer propagation diverges rays\n');
+    failed = failed + 1;
+end
+
+fprintf('\n=== RayTracing: %d/%d passed ===\n', passed, passed + failed);
+
+if failed ~= 0
+    error('Tests failed: %d/%d', failed, passed + failed);
 end


### PR DESCRIPTION
## Summary

- Fixed MATLAB error: `Superclass constructor call to 'ParaxialBeam' must not be conditional or part of another expression`
- All 6 beam subclasses had the same bug: `obj@ParaxialBeam()` was inside conditional `if` blocks
- MATLAB requires the superclass constructor to be the **first statement** in the constructor, unconditionally

## Files Changed

| File | Change |
|------|--------|
| `src/beams/GaussianBeam.m` | Restructured constructor + added static `parseArgs()` |
| `src/beams/ElegantHermiteBeam.m` | Same fix pattern |
| `src/beams/ElegantLaguerreBeam.m` | Same fix pattern |
| `src/beams/HermiteBeam.m` | Same fix pattern |
| `src/beams/LaguerreBeam.m` | Same fix pattern |
| `src/beams/HankelLaguerre.m` | Same fix pattern (uses positional args) |

## The Fix Pattern

**Before (invalid MATLAB):**
```matlab
function obj = MyBeam(arg1, arg2)
    if nargin == 0
        obj = obj@ParaxialBeam();  % INSIDE conditional - ERROR
        return;
    end
    if nargin == 2
        obj = obj@ParaxialBeam(arg2);  % ALSO inside conditional - ERROR
        ...
    end
end
```

**After (valid MATLAB):**
```matlab
function obj = MyBeam(arg1, arg2)
    % Super constructor FIRST - MATLAB requirement
    obj = obj@ParaxialBeam();
    
    % Parse args AFTER super constructor using static helper
    [w0, lambda, ...] = MyBeam.parseArgs(arg1, arg2);
    
    % Now set properties
    if ~isempty(lambda)
        obj.Lambda = lambda;
        obj.k = 2 * pi / lambda;
    end
    ...
end

methods (Static)
    function [w0, lambda, ...] = parseArgs(arg1, arg2)
        % Handle all argument combinations
    end
end
```

## Testing

The CI should now pass all tests that were failing due to this error.