### PR TITLE
chore(legacy): enforce canonical alias guardrail

### DIFF
--- a/docs/migration/RELEASE_CHECKPOINT_2026-04-22.md
+++ b/docs/migration/RELEASE_CHECKPOINT_2026-04-22.md
@@ -1,0 +1,40 @@
+# Release Checkpoint - 2026-04-22
+
+## Scope
+
+This checkpoint closes the post-merge architecture hardening after:
+
+- PR #24 (`feat/parameters-cleanup-sdd`)
+- PR #25 (`chore/parameters-next-steps`)
+
+Focus is architecture consistency, migration readiness, and guardrails against legacy reintroduction.
+
+## Included
+
+- `BeamComputation` + `HermiteComputation` extraction is merged in `master`.
+- `GaussianParameters` now delegates static helpers through `BeamComputation` (no residual formula split).
+- Canonical smoke compatibility validated and plotting issues fixed in `MainGauss_refactored`.
+- Legacy removal policy documented with explicit readiness gates (Usage/Test/Docs/Release).
+- New guardrail test added:
+  - `tests/modern/test_LegacyAliasGuardrail.m`
+  - Enforced from `portable_runner.m`
+  - Fails if deprecated `Hankele*` aliases appear in:
+    - `examples/canonical/`
+    - `tests/modern/`
+
+## Validation Snapshot
+
+- `master` includes merge commit `e44d32e` (PR #25).
+- `portable_runner` now includes the legacy alias guardrail test.
+
+## Not Included
+
+- Removal of `legacy/compat/Hankele*.m` aliases.
+- Retirement of `tests/legacy_compat/`.
+- Package migration from `src/` to `+paraxial/`.
+
+## Next Phase Recommendation
+
+1. Keep guardrail green for at least one release cycle.
+2. Collect user impact signal (if anyone still depends on `Hankele*`).
+3. When readiness gates are fully green, execute the documented removal checklist in `LEGACY_MIGRATION_PLAN.md`.

--- a/tests/modern/test_LegacyAliasGuardrail.m
+++ b/tests/modern/test_LegacyAliasGuardrail.m
@@ -1,0 +1,59 @@
+% Guardrail: prevent deprecated Hankele* aliases in canonical/modern surfaces
+
+repoRoot = fullfile(fileparts(fileparts(fileparts(mfilename('fullpath')))));
+
+fprintf('=== Legacy Alias Guardrail Tests ===\n\n');
+passed = 0;
+failed = 0;
+
+forbiddenAliases = {'HankeleHermite', 'HankeleLaguerre'};
+
+targets = {
+    fullfile(repoRoot, 'examples', 'canonical'),
+    fullfile(repoRoot, 'tests', 'modern')
+};
+
+violations = {};
+
+for t = 1:numel(targets)
+    dirPath = targets{t};
+    files = dir(fullfile(dirPath, '*.m'));
+
+    for i = 1:numel(files)
+        filePath = fullfile(dirPath, files(i).name);
+
+        % Ignore this guardrail test file to avoid self-matching constants.
+        if strcmp(files(i).name, 'test_LegacyAliasGuardrail.m')
+            continue;
+        end
+
+        content = fileread(filePath);
+
+        for a = 1:numel(forbiddenAliases)
+            alias = forbiddenAliases{a};
+            % Match token usage to reduce false positives.
+            hasAlias = ~isempty(regexp(content, ['\<' alias '\>'], 'once'));
+
+            if hasAlias
+                violations{end+1} = sprintf('%s -> %s', filePath, alias); %#ok<AGROW>
+            end
+        end
+    end
+end
+
+if isempty(violations)
+    fprintf('  PASS: no deprecated Hankele* aliases in canonical/modern surfaces\n');
+    passed = passed + 1;
+else
+    fprintf('  FAIL: found deprecated Hankele* alias usage\n');
+    for i = 1:numel(violations)
+        fprintf('    - %s\n', violations{i});
+    end
+    failed = failed + 1;
+end
+
+fprintf('\n=== Legacy Alias Guardrail: %d/%d passed ===\n', passed, passed + failed);
+
+if failed ~= 0
+    error('Legacy alias guardrail failed: %d violation group(s).', failed);
+end

--- a/tests/portable_runner.m
+++ b/tests/portable_runner.m
@@ -50,6 +50,7 @@ function totalFailed = portable_runner()
         'test_OpticalRay.m',
         'test_AnalysisUtils.m',
         'test_BeamFactory.m',
+        'test_LegacyAliasGuardrail.m',
         'test_Propagators.m',
         'test_RayTracing.m',
         fullfile(testDir, 'legacy_compat', 'test_HankelCompatibility.m'),


### PR DESCRIPTION
Add a modern test that fails if deprecated Hankele* aliases appear in canonical examples or modern tests, wire it into portable_runner, and record the 2026-04-22 post-merge checkpoint for PR #24/#25 hardening.