### PR TITLE
feat(paraxial): add +paraxial package with namespaced classes

### DIFF
--- a/examples/canonical/ExampleWavefront.m
+++ b/examples/canonical/ExampleWavefront.m
@@ -1,0 +1,88 @@
+%% Canonical Example: Wavefront Analysis
+%% Demonstrates wavefront extraction, Zernike fitting, and metrics.
+%
+% This script shows:
+%   1. Creating Wavefront from complex field
+%   2. Extracting phase and intensity
+%   3. Zernike polynomial fitting
+%   4. Computing wavefront metrics (RMS, PV, Strehl)
+%   5. Visualization of results
+
+scriptPath = fileparts(mfilename('fullpath'));
+repoRoot = fullfile(scriptPath, '..', '..');
+addpath(repoRoot);
+setpaths();
+
+%% Create a Gaussian beam field
+fprintf('Creating Gaussian beam field...\n');
+w0 = 100e-6;       % 100 microns
+lambda = 632.8e-9; % HeNe laser
+z = 0;             % at waist (planar wavefront)
+
+grid = GridUtils(256, 256, 1e-3, 1e-3);
+[X, Y] = grid.create2DGrid();
+
+beam = BeamFactory.create('gaussian', w0, lambda);
+E = beam.opticalField(X, Y, z);
+
+%% Create Wavefront from field
+fprintf('Creating Wavefront object...\n');
+wf = Wavefront(E, lambda, grid);
+
+%% Extract field properties
+fprintf('\n--- Field Properties ---\n');
+I = wf.getIntensity();
+phi = wf.getPhase();
+fprintf('Grid size: %d x %d\n', wf.Ny, wf.Nx);
+fprintf('Intensity range: [%.3f, %.3f]\n', min(I(:)), max(I(:)));
+
+%% Fit Zernike polynomials
+fprintf('\n--- Zernike Fitting ---\n');
+nTerms = 36;
+coeffs = wf.fitZernike(nTerms);
+fprintf('Fitted %d Zernike terms\n', nTerms);
+fprintf('Piston (Z1): %.6f rad\n', coeffs(1));
+fprintf('Tilt X (Z2): %.6f rad\n', coeffs(2));
+fprintf('Tilt Y (Z3): %.6f rad\n', coeffs(3));
+
+%% Compute metrics
+fprintf('\n--- Wavefront Metrics ---\n');
+metrics = wf.getMetrics(nTerms);
+fprintf('RMS wavefront error: %.6f rad (%.4f waves)\n', ...
+    metrics.rms, metrics.rms/(2*pi));
+fprintf('PV wavefront error: %.6f rad (%.4f waves)\n', ...
+    metrics.pv, metrics.pv/(2*pi));
+fprintf('Strehl ratio: %.4f\n', metrics.strehl);
+fprintf('Residual RMS (36 terms): %.2e rad\n', metrics.residualRMS);
+
+%% Visualize results
+fprintf('\n--- Generating visualizations ---\n');
+
+% Phase map
+figure(1);
+wf.plotWavefront();
+title(sprintf('Gaussian Beam Phase (z=0, waist)'));
+
+% Intensity
+figure(2);
+wf.plotIntensity();
+title(sprintf('Gaussian Beam Intensity'));
+
+% Zernike coefficients
+figure(3);
+wf.plotZernikeCoeffs(coeffs);
+title(sprintf('Zernike Coefficients (1-%d)', nTerms));
+
+% Phase slice
+figure(4);
+wf.plotPhaseSlice('x', floor(wf.Ny/2));
+title('Phase Slice at Center');
+
+%% Verify planar wavefront behavior
+fprintf('\n--- Verification ---\n');
+fprintf('At waist (z=0), Gaussian beam has planar wavefront:\n');
+fprintf('  - Piston term dominant: %.6f rad\n', coeffs(1));
+fprintf('  - Tilt terms ~0: Z2=%.6f, Z3=%.6f\n', coeffs(2), coeffs(3));
+fprintf('  - Strehl ratio ~1 (no aberration): %.4f\n', metrics.strehl);
+
+fprintf('\nDone.\n');

--- a/openspec/changes/wavefront-class/design.md
+++ b/openspec/changes/wavefront-class/design.md
@@ -1,0 +1,138 @@
+# Design: Wavefront Class
+
+## Technical Approach
+
+Create `Wavefront` as a standalone class in `src/visualization/` that wraps complex field data and provides wavefront analysis methods. It follows the existing class patterns (static helpers, static computation delegation).
+
+## Architecture Decisions
+
+### Decision: Class Location
+
+**Choice**: Create in `src/visualization/Wavefront.m`
+
+**Alternatives**: New `src/wavefront/` folder
+**Rationale**: `Wavefront` is primarily a visualization/analysis tool; fits with `VisualizationUtils`.
+
+### Decision: Zernike Implementation
+
+**Choice**: Use Noll indexing with standard definitions; compute via explicit formulas
+
+```matlab
+methods (Static)
+    function Z = zernike(n, rho, theta)
+        % Noll standard Zernike polynomials
+        switch n
+            case 1, Z = ones(size(rho));                    % Piston
+            case 2, Z = 2*rho.*cos(theta);                  % Tilt X
+            case 3, Z = 2*rho.*sin(theta);                  % Tilt Y
+            case 4, Z = sqrt(3)*(2*rho.^2 - 1);            % Defocus
+            % ... up to 36
+        end
+    end
+end
+```
+
+**Alternatives**: Use symbolic toolbox, external library
+**Rationale**: Explicit formulas are self-contained, no dependencies, fast.
+
+### Decision: Least-Squares Fitting
+
+**Choice**: Use pseudo-inverse for Zernike coefficient fitting
+
+```matlab
+function coeffs = fitZernike(obj, nTerms)
+    [rho, theta] = obj.gridPolar();
+    Z = obj.buildZernikeMatrix(rho, theta, nTerms);
+    coeffs = pinv(Z) * obj.phase(:);  % Least-squares
+end
+```
+
+**Rationale**: `pinv` handles ill-conditioned matrices gracefully.
+
+### Decision: Phase Storage
+
+**Choice**: Store wrapped phase (`angle(E)`); unwrap on demand
+
+**Rationale**: Preserves original data; unwrapping is lossy.
+
+## Data Flow
+
+```
+ParaxialBeam.opticalField(X, Y, z)
+        │
+        ▼ (complex field)
+   Wavefront(field, lambda, grid)
+        │
+        ├── getPhase() ────────────────────► wrap/unwrap
+        ├── fitZernike(n) ─────────────────► Zernike coefficients
+        ├── computeRMS() ──────────────────► scalar metrics
+        ├── computeStrehl() ───────────────► Strehl ratio
+        └── plotWavefront() ───────────────► visualization
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/visualization/Wavefront.m` | Create | Main Wavefront class |
+| `src/visualization/ZernikeUtils.m` | Create | Static Zernike computation helpers |
+| `docs/ARCHITECTURE.md` | Modify | Add Wavefront section |
+| `examples/canonical/ExampleWavefront.m` | Create | New canonical example |
+
+## Interfaces / Contracts
+
+### Wavefront Constructor
+
+```matlab
+wf = Wavefront(E, lambda)           % Minimal
+wf = Wavefront(E, lambda, grid)     % With GridUtils
+wf = Wavefront(E, lambda, dx, dy)   % With explicit spacing
+```
+
+### Key Methods
+
+```matlab
+phi = wf.getPhase()                    % Wrapped phase
+I = wf.getIntensity()                  % |E|^2
+coeffs = wf.fitZernike(36)            % Fit 36 terms
+rms = wf.computeRMS()                  % RMS wavefront error
+pv = wf.computePV()                    % Peak-to-valley
+strehl = wf.computeStrehl()            % Strehl ratio
+wf.plotWavefront()                     % Phase map visualization
+```
+
+### ZernikeUtils Static Helpers
+
+```matlab
+ZernikeUtils.zernike(n, rho, theta)      % Compute Z_n
+ZernikeUtils.zernikeName(n)               % 'Defocus', etc.
+ZernikeUtils.zernikeMatrix(rho, theta, N) % Build design matrix
+```
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Zernike formulas vs known values | Test Z1=1, Z2∝cos, etc. |
+| Unit | RMS/PV calculations | GaussianBeam has analytic solution |
+| Unit | Strehl formula | Verify exp(-(2πσ/λ)²) |
+| Integration | Round-trip: fit → reconstruct | RMS residual < 1e-10 |
+| Integration | GaussianBeam → Wavefront | Known analytical wavefront |
+
+### Verification Test: GaussianBeam
+
+Gaussian beam at waist (z=0) has planar wavefront → only piston term ≠ 0.
+
+```matlab
+beam = BeamFactory.create('gaussian', 100e-6, 632.8e-9);
+E = beam.opticalField(X, Y, 0);
+wf = Wavefront(E, lambda, grid);
+coeffs = wf.fitZernike(36);
+% coeffs(1) ≈ mean phase, all others ≈ 0
+```
+
+## Open Questions
+
+- [ ] Unwrapping algorithm: use IED (Itoh) or Goldstein? Recommendation: **Goldstein** for simplicity
+- [ ] Should Wavefront support multiple wavelengths per instance? Recommendation: **No** — one wavelength per instance
+- [ ] Zernike normalization: Noll standard vs. Fringe? Recommendation: **Noll** (standard in optics)

--- a/openspec/changes/wavefront-class/proposal.md
+++ b/openspec/changes/wavefront-class/proposal.md
@@ -1,0 +1,77 @@
+# Proposal: Wavefront Class
+
+## Intent
+
+Introduce a `Wavefront` class for analyzing optical wavefronts from beam fields. This enables Zernike decomposition, wavefront error analysis, and Strehl ratio calculation — common tasks in optical system characterization and adaptive optics.
+
+## Scope
+
+### In Scope
+- Create `Wavefront` class in `src/visualization/` (not a package yet)
+- Store complex field data `[Ny x Nx]` and metadata (wavelength, grid)
+- Compute intensity and phase from complex field
+- Calculate wavefront gradient (for deformable mirror input)
+- Zernike polynomial fitting (standard 36-term set)
+- Wavefront error metrics: RMS, PV (peak-to-valley)
+- Strehl ratio estimation from wavefront error
+- Static visualization methods for wavefront and Zernike coefficients
+
+### Out of Scope
+- Adaptive optics closed-loop control
+- Temporal wavefront analysis
+- Integration with DeformableMirror class (future work)
+- Propagation through optical systems
+
+## Capabilities
+
+### New Capabilities
+- `wavefront-extraction`: Extract wavefront (phase) from complex field data
+- `zernike-fitting`: Fit Zernike polynomials to wavefront error
+- `wavefront-metrics`: Compute RMS, PV, Strehl ratio
+- `wavefront-visualization`: Plot wavefront maps and Zernike bar charts
+
+## Approach
+
+1. **Input**: Receive complex field `[Ny x Nx]` from existing beam's `opticalField()`
+2. **Storage**: Store field, wavelength, grid spacing, reference radius
+3. **Analysis**: Phase extraction → unwrapping (if needed) → Zernike fit → metrics
+4. **Output**: Metrics struct, Zernike coefficients vector, residual map
+5. **Visualization**: 2D phase map, Zernike coefficient bar chart, intensity overlay
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `src/visualization/` | New | New `Wavefront.m` class |
+| `docs/ARCHITECTURE.md` | Modified | Add Wavefront section |
+| `examples/canonical/` | Modified | Add `ExampleWavefront.m` |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Phase unwrapping edge cases | Medium | Start with analytical beams (known phase) for testing |
+| Zernike normalization | Low | Use standard Noll indexing and normalization |
+| Grid coordinate handling | Medium | Accept GridUtils input directly |
+
+## Rollback Plan
+
+1. Revert PR, delete `src/visualization/Wavefront.m`
+2. Remove `ExampleWavefront.m`
+3. Revert ARCHITECTURE.md changes
+
+## Dependencies
+
+- Requires: `GridUtils` for grid metadata
+- Works with: any `ParaxialBeam` subclass
+
+## Success Criteria
+
+- [ ] `Wavefront(field, lambda, grid)` constructor works
+- [ ] `getPhase()` returns unwrapped phase `[Ny x Nx]`
+- [ ] `fitZernike(nTerms)` returns coefficient vector
+- [ ] `computeRMS()` and `computePV()` return scalar values
+- [ ] `computeStrehl()` returns ratio 0-1
+- [ ] `plotWavefront()` displays phase map
+- [ ] Test with GaussianBeam field: known analytical solution for verification
+- [ ] Tests pass in Octave and MATLAB CI

--- a/openspec/changes/wavefront-class/specs/wavefront-extraction/spec.md
+++ b/openspec/changes/wavefront-class/specs/wavefront-extraction/spec.md
@@ -1,0 +1,56 @@
+# wavefront-extraction Specification
+
+## Purpose
+
+Extract wavefront (phase) information from complex optical field data.
+
+## ADDED Requirements
+
+### Requirement: Constructor with Field Data
+
+The system MUST accept a complex field `[Ny x Nx]` array along with wavelength and optional grid metadata.
+
+#### Scenario: Minimal Constructor
+
+- GIVEN a complex field `E` of size [256, 256]
+- WHEN user creates `wf = Wavefront(E, lambda)`
+- THEN the system SHALL store `E` and `lambda`
+- AND SHALL derive grid size from `size(E)`
+
+#### Scenario: Constructor with Grid
+
+- GIVEN complex field `E`, wavelength `lambda`, and GridUtils `grid`
+- WHEN user creates `wf = Wavefront(E, lambda, grid)`
+- THEN the system SHALL store grid metadata (dx, dy, Dx, Dy)
+
+### Requirement: Getter Methods
+
+The system MUST provide these getters:
+- `getIntensity()` — returns `abs(E).^2`
+- `getPhase()` — returns `angle(E)` wrapped to [-pi, pi]
+- `getField()` — returns original complex field
+
+#### Scenario: Get Intensity
+
+- GIVEN `Wavefront` instance `wf`
+- WHEN user calls `I = wf.getIntensity()`
+- THEN `I` SHALL be [Ny x Nx] real array
+
+#### Scenario: Get Phase
+
+- GIVEN `Wavefront` instance `wf`
+- WHEN user calls `phi = wf.getPhase()`
+- THEN `phi` SHALL be [Ny x Nx] real array in [-pi, pi]
+
+### Requirement: Grid Info Storage
+
+The system SHOULD store these grid metadata properties:
+- `dx`, `dy` — grid spacing in meters
+- `Dx`, `Dy` — grid extent in meters
+- `wavelength` — in meters
+
+#### Scenario: Grid Metadata Preserved
+
+- GIVEN `Wavefront(E, lambda, grid)` constructor
+- WHEN `wf.dx` is accessed
+- THEN it SHALL return `grid.dx` value

--- a/openspec/changes/wavefront-class/specs/wavefront-metrics/spec.md
+++ b/openspec/changes/wavefront-class/specs/wavefront-metrics/spec.md
@@ -1,0 +1,60 @@
+# wavefront-metrics Specification
+
+## Purpose
+
+Compute wavefront error metrics for optical quality assessment.
+
+## ADDED Requirements
+
+### Requirement: RMS Calculation
+
+The system MUST compute the root-mean-square wavefront error.
+
+#### Scenario: Compute RMS
+
+- GIVEN `Wavefront` instance with phase `phi`
+- WHEN user calls `rms = wf.computeRMS()`
+- THEN `rms` SHALL be a scalar in the same units as `phi` (radians or meters)
+
+#### Scenario: RMS from Fitted Coefficients
+
+- GIVEN `Wavefront` instance
+- WHEN user calls `rms = wf.computeRMS(coeffs)`
+- THEN `rms` SHALL be computed from the fitted wavefront only (excluding residual)
+
+### Requirement: Peak-to-Valley (PV) Calculation
+
+The system MUST compute peak-to-valley wavefront error.
+
+#### Scenario: Compute PV
+
+- GIVEN `Wavefront` instance with phase `phi`
+- WHEN user calls `pv = wf.computePV()`
+- THEN `pv` SHALL equal `max(phi) - min(phi)`
+
+### Requirement: Strehl Ratio Estimation
+
+The system MUST estimate Strehl ratio from wavefront error using the Maréchal approximation.
+
+#### Scenario: Compute Strehl
+
+- GIVEN `Wavefront` instance with RMS wavefront error `sigma`
+- WHEN user calls `strehl = wf.computeStrehl()`
+- THEN `strehl` SHALL be `exp(-(2*pi*sigma/lambda)^2)` for small sigma
+- AND `strehl` SHALL be between 0 and 1
+
+#### Scenario: Strehl with Known WFE
+
+- GIVEN `Wavefront` instance with `sigma = lambda/10`
+- WHEN user calls `strehl = wf.computeStrehl()`
+- THEN `strehl` SHALL be approximately `exp(-(2*pi/10)^2) ≈ 0.67`
+
+### Requirement: Wavefront Error Structure
+
+The system MAY provide a structured output with all metrics.
+
+#### Scenario: Get Metrics Struct
+
+- GIVEN `Wavefront` instance
+- WHEN user calls `metrics = wf.getMetrics()`
+- THEN `metrics` SHALL be a struct with fields: `rms`, `pv`, `strehl`, `residualRMS`

--- a/openspec/changes/wavefront-class/specs/wavefront-visualization/spec.md
+++ b/openspec/changes/wavefront-class/specs/wavefront-visualization/spec.md
@@ -1,0 +1,50 @@
+# wavefront-visualization Specification
+
+## Purpose
+
+Visualize wavefront phase maps and Zernike decomposition results.
+
+## ADDED Requirements
+
+### Requirement: Wavefront Phase Map Plot
+
+The system MUST provide a method to plot the 2D wavefront phase map.
+
+#### Scenario: Plot Wavefront Phase
+
+- GIVEN `Wavefront` instance `wf`
+- WHEN user calls `wf.plotWavefront()`
+- THEN it SHALL create a figure with a 2D phase map
+- AND colorbar SHALL show phase in radians or waves
+
+### Requirement: Intensity Plot
+
+The system MUST provide a method to plot the intensity distribution.
+
+#### Scenario: Plot Intensity
+
+- GIVEN `Wavefront` instance `wf`
+- WHEN user calls `wf.plotIntensity()`
+- THEN it SHALL create a figure with 2D intensity map
+- AND axis labels SHALL be in meters
+
+### Requirement: Zernike Coefficient Bar Chart
+
+The system MUST provide a method to plot Zernike coefficients as a bar chart.
+
+#### Scenario: Plot Zernike Coefficients
+
+- GIVEN `Wavefront` instance with fitted coefficients
+- WHEN user calls `wf.plotZernikeCoeffs(coeffs)`
+- THEN it SHALL create a bar chart with coefficient values
+- AND x-axis labels SHALL show Zernike names (Piston, Tilt X, ...)
+
+### Requirement: Phase Slice Plot
+
+The system MAY provide a 1D phase slice plot along a cross-section.
+
+#### Scenario: Plot Phase Slice
+
+- GIVEN `Wavefront` instance with phase `phi`
+- WHEN user calls `wf.plotPhaseSlice('x', Ny/2)`
+- THEN it SHALL plot `phi(Ny/2, :)` vs x-axis

--- a/openspec/changes/wavefront-class/specs/zernike-fitting/spec.md
+++ b/openspec/changes/wavefront-class/specs/zernike-fitting/spec.md
@@ -1,0 +1,65 @@
+# zernike-fitting Specification
+
+## Purpose
+
+Fit Zernike polynomials to wavefront data for modal decomposition and optical quality assessment.
+
+## ADDED Requirements
+
+### Requirement: Zernike Polynomial Computation
+
+The system MUST compute Zernike polynomials using standard Noll indexing.
+
+#### Scenario: Zernike Standard Indices
+
+- GIVEN Zernike index `n = 4` (defocus)
+- WHEN system computes `Z4(rho, theta)`
+- THEN it SHALL use standard Noll definition: Z4 = sqrt(3)*(2*rho^2 - 1)
+
+### Requirement: Fit Zernike Coefficients
+
+The system MUST fit Zernike coefficients to a wavefront phase map using least-squares.
+
+#### Scenario: Fit First 36 Terms
+
+- GIVEN `Wavefront` instance with phase `phi`
+- WHEN user calls `coeffs = wf.fitZernike(36)`
+- THEN `coeffs` SHALL be a [36 x 1] column vector
+- AND `coeffs(1)` SHALL be piston (mean offset)
+
+#### Scenario: Fit Custom Number of Terms
+
+- GIVEN `Wavefront` instance with phase `phi`
+- WHEN user calls `coeffs = wf.fitZernike(nTerms)`
+- THEN `coeffs` SHALL have exactly `nTerms` entries
+
+### Requirement: Reconstruct Wavefront
+
+The system MUST reconstruct the wavefront from fitted coefficients.
+
+#### Scenario: Round-Trip Reconstruction
+
+- GIVEN `Wavefront` instance
+- WHEN user fits and reconstructs: `phi_fit = wf.fitZernike(36); phi_rec = wf.reconstructZernike(phi_fit)`
+- THEN the residual error `norm(phi - phi_rec)` SHALL be small (RMS < 1e-10)
+
+### Requirement: Standard Noll Set (36 Terms)
+
+The system SHALL support at minimum these 36 Zernike terms:
+1. Piston, 2. Tilt X, 3. Tilt Y, 4. Defocus, 5-6. Astigmatism, 7-8. Coma, 9-10. Spherical, and higher orders up to 36.
+
+#### Scenario: Terms 1-36 Available
+
+- GIVEN `fitZernike(36)` call
+- WHEN terms are computed
+- THEN all 36 standard Noll Zernike polynomials SHALL be correctly defined
+
+### Requirement: Zernike Names
+
+The system SHOULD provide names for each Zernike index for display purposes.
+
+#### Scenario: Get Zernike Name
+
+- GIVEN `Wavefront` instance
+- WHEN user calls `name = wf.zernikeName(4)`
+- THEN `name` SHALL be `'Defocus'`

--- a/openspec/changes/wavefront-class/tasks.md
+++ b/openspec/changes/wavefront-class/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: Wavefront Class
+
+## Phase 1: Zernike Utilities
+
+- [x] 1.1 Create `src/visualization/ZernikeUtils.m` with static `zernike(n, rho, theta)` method
+- [x] 1.2 Implement Noll Zernike formulas for n=1..36
+- [x] 1.3 Add `zernikeName(n)` static method returning names: 'Piston', 'Tilt X', 'Defocus', etc.
+- [x] 1.4 Add `zernikeMatrix(rho, theta, nTerms)` static method building design matrix
+
+## Phase 2: Wavefront Core Class
+
+- [x] 2.1 Create `src/visualization/Wavefront.m` classdef with properties: field, wavelength, dx, dy, Dx, Dy
+- [x] 2.2 Implement constructor: `Wavefront(E, lambda)` and `Wavefront(E, lambda, grid)`
+- [x] 2.3 Implement `getField()` returning complex field
+- [x] 2.4 Implement `getIntensity()` returning `abs(E).^2`
+- [x] 2.5 Implement `getPhase()` returning `angle(E)` (wrapped)
+
+## Phase 3: Grid Helpers
+
+- [x] 3.1 Add `gridPolar()` method returning rho, theta from stored grid info
+- [x] 3.2 Add `gridCartesian()` method returning X, Y grids
+
+## Phase 4: Zernike Fitting
+
+- [x] 4.1 Implement `fitZernike(nTerms)` using `pinv(ZernikeMatrix)` least-squares
+- [x] 4.2 Implement `reconstructZernike(coeffs)` to rebuild phase from coefficients
+- [x] 4.3 Implement `zernikeResidual(nTerms)` returning residual error
+
+## Phase 5: Metrics
+
+- [x] 5.1 Implement `computeRMS()` returning scalar RMS of phase
+- [x] 5.2 Implement `computePV()` returning `max(phi) - min(phi)`
+- [x] 5.3 Implement `computeStrehl()` using Maréchal approximation: `exp(-(2*pi*sigma/lambda)^2)`
+- [x] 5.4 Implement `getMetrics()` returning struct with rms, pv, strehl
+
+## Phase 6: Visualization
+
+- [x] 6.1 Implement `plotWavefront()` showing 2D phase map with colorbar
+- [x] 6.2 Implement `plotIntensity()` showing 2D intensity map
+- [x] 6.3 Implement `plotZernikeCoeffs(coeffs)` bar chart with Zernike names
+- [x] 6.4 Implement `plotPhaseSlice(plane, idx)` 1D cross-section
+
+- [x] 7.1 Create `tests/test_Wavefront.m` with basic constructor tests
+- [x] 7.2 Test Zernike Z1=1 (piston), Z2∝cos (tilt X), Z4=sqrt(3)*(2ρ²-1) (defocus)
+- [x] 7.3 Test: Gaussian beam at waist → only piston term ≠ 0 (all others ~0)
+- [x] 7.4 Test: fitZernike → reconstructZernike round-trip residual < 1e-10
+- [x] 7.5 Test: RMS/PV calculations against known values
+- [x] 7.6 Test: Strehl calculation for sigma = lambda/10 → ~0.67
+
+## Phase 8: Documentation & Examples
+
+- [x] 8.1 Create `examples/canonical/ExampleWavefront.m` demonstrating all features
+- [x] 8.2 Update `docs/ARCHITECTURE.md` with Wavefront section
+- [ ] 8.3 Register `tests/test_Wavefront.m` in `tests/test_all.m`

--- a/src/visualization/Wavefront.m
+++ b/src/visualization/Wavefront.m
@@ -1,0 +1,319 @@
+classdef Wavefront
+    % Wavefront - Optical wavefront analysis class
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Provides wavefront extraction, Zernike decomposition, and metrics
+    % for optical beam characterization.
+    %
+    % Usage:
+    %   wf = Wavefront(E, lambda)              % minimal constructor
+    %   wf = Wavefront(E, lambda, grid)       % with GridUtils
+    %
+    %   phi = wf.getPhase();                  % wrapped phase
+    %   I = wf.getIntensity();                % |E|^2
+    %   coeffs = wf.fitZernike(36);          % fit 36 Zernike terms
+    %   rms = wf.computeRMS();               % wavefront RMS
+    %   strehl = wf.computeStrehl();         % Strehl ratio
+
+    properties
+        Field               % Complex field [Ny x Nx]
+        Lambda = 632.8e-9   % Wavelength [m]
+        dx = 1e-5           % Grid spacing x [m]
+        dy = 1e-5            % Grid spacing y [m]
+        Dx = 1e-3            % Grid extent x [m]
+        Dy = 1e-3            % Grid extent y [m]
+    end
+
+    properties (Dependent, Hidden)
+        Ny, Nx              % Grid dimensions (derived from Field)
+    end
+
+    methods
+        function obj = Wavefront(E, lambda, varargin)
+            % Constructor
+            %   wf = Wavefront(E, lambda)              % minimal
+            %   wf = Wavefront(E, lambda, grid)         % with GridUtils
+
+            if nargin == 0
+                return; % empty object
+            end
+
+            obj.Field = E;
+            obj.Lambda = lambda;
+
+            % Handle optional grid argument
+            if nargin >= 3
+                grid = varargin{1};
+                if isa(grid, 'GridUtils')
+                    obj.dx = grid.dx;
+                    obj.dy = grid.dy;
+                    obj.Dx = grid.Dx;
+                    obj.Dy = grid.Dy;
+                else
+                    error('Wavefront:invalidGrid', ...
+                        'Third argument must be a GridUtils instance');
+                end
+            end
+        end
+
+        % -----------------------------------------------------------------
+        % Dependent properties
+        % -----------------------------------------------------------------
+        function Ny = get.Ny(obj)
+            Ny = size(obj.Field, 1);
+        end
+
+        function Nx = get.Nx(obj)
+            Nx = size(obj.Field, 2);
+        end
+
+        % -----------------------------------------------------------------
+        % Field getters
+        % -----------------------------------------------------------------
+
+        function E = getField(obj)
+            % getField - Return the complex field
+            E = obj.Field;
+        end
+
+        function I = getIntensity(obj)
+            % getIntensity - Return intensity |E|^2
+            I = abs(obj.Field).^2;
+        end
+
+        function phi = getPhase(obj)
+            % getPhase - Return wrapped phase angle(E) in [-pi, pi]
+            phi = angle(obj.Field);
+        end
+
+        % -----------------------------------------------------------------
+        % Grid helpers
+        % -----------------------------------------------------------------
+
+        function [rho, theta] = gridPolar(obj)
+            % gridPolar - Return polar grid coordinates (normalized)
+            %   rho normalized to [0, 1] at edge of grid
+            %   theta in [-pi, pi]
+
+            [X, Y] = obj.gridCartesian();
+
+            % Normalize to unit circle (use max extent)
+            maxR = min(obj.Dx/2, obj.Dy/2);
+            rho = sqrt(X.^2 + Y.^2) / maxR;
+            theta = atan2(Y, X);
+
+            % Clip rho to [0, 1]
+            rho = min(1, max(0, rho));
+        end
+
+        function [X, Y] = gridCartesian(obj)
+            % gridCartesian - Return Cartesian grid arrays
+            nx = (-obj.Nx/2:obj.Nx/2-1) * obj.dx;
+            ny = (-obj.Ny/2:obj.Ny/2-1) * obj.dy;
+            [X, Y] = meshgrid(nx, ny);
+        end
+
+        % -----------------------------------------------------------------
+        % Zernike fitting
+        % -----------------------------------------------------------------
+
+        function coeffs = fitZernike(obj, nTerms)
+            % fitZernike - Fit Zernike polynomial coefficients (least-squares)
+            %
+            %   coeffs = wf.fitZernike(36)  % fit 36 terms
+            %
+            % Returns:
+            %   coeffs - [nTerms x 1] column vector of Zernike coefficients
+
+            if nTerms < 1 || nTerms > 36
+                error('Wavefront:invalidNTerms', ...
+                    'nTerms must be 1-36, got %d', nTerms);
+            end
+
+            [rho, theta] = obj.gridPolar();
+            phi = obj.getPhase();
+
+            % Build design matrix and fit via pseudo-inverse
+            M = ZernikeUtils.zernikeMatrix(rho, theta, nTerms);
+            coeffs = pinv(M) * phi(:);  % least-squares solution
+            coeffs = coeffs(:);  % ensure column vector
+        end
+
+        function phi_recon = reconstructZernike(obj, coeffs)
+            % reconstructZernike - Reconstruct wavefront from Zernike coefficients
+            %
+            %   phi_recon = wf.reconstructZernike(coeffs);
+
+            [rho, theta] = obj.gridPolar();
+            nTerms = length(coeffs);
+
+            M = ZernikeUtils.zernikeMatrix(rho, theta, nTerms);
+            phi_recon = reshape(M * coeffs, obj.Ny, obj.Nx);
+        end
+
+        function residual = zernikeResidual(obj, nTerms)
+            % zernikeResidual - RMS residual after fitting nTerms Zernikes
+            coeffs = obj.fitZernike(nTerms);
+            phi_fit = obj.reconstructZernike(coeffs);
+            phi_orig = obj.getPhase();
+            residual = sqrt(mean((phi_orig(:) - phi_fit(:)).^2));
+        end
+
+        % -----------------------------------------------------------------
+        % Metrics
+        % -----------------------------------------------------------------
+
+        function rms = computeRMS(obj, varargin)
+            % computeRMS - Root-mean-square wavefront error
+            %
+            %   rms = wf.computeRMS()              % RMS of full phase
+            %   rms = wf.computeRMS(coeffs)        % RMS from fitted Zernikes only
+
+            if nargin == 1
+                % RMS of actual phase
+                phi = obj.getPhase();
+                rms = sqrt(mean(phi(:).^2));
+            else
+                % RMS from fitted coefficients only (excludes residual)
+                coeffs = varargin{1};
+                phi_fit = obj.reconstructZernike(coeffs);
+                rms = sqrt(mean(phi_fit(:).^2));
+            end
+        end
+
+        function pv = computePV(obj)
+            % computePV - Peak-to-valley wavefront error
+            phi = obj.getPhase();
+            pv = max(phi(:)) - min(phi(:));
+        end
+
+        function strehl = computeStrehl(obj)
+            % computeStrehl - Strehl ratio via Maréchal approximation
+            %
+            %   strehl = exp(-(2*pi*sigma/lambda)^2)
+            %
+            % where sigma is RMS wavefront error.
+
+            sigma = obj.computeRMS();
+            strehl = exp(-(2 * pi * sigma / obj.Lambda)^2);
+
+            % Clamp to [0, 1] (numerical precision can exceed bounds)
+            strehl = max(0, min(1, strehl));
+        end
+
+        function metrics = getMetrics(obj, nTerms)
+            % getMetrics - Compute all wavefront metrics
+            %
+            %   metrics = wf.getMetrics(nTerms)   % include Zernike fitting
+            %   metrics = wf.getMetrics()          % use 36 terms
+
+            if nargin < 2
+                nTerms = 36;
+            end
+
+            coeffs = obj.fitZernike(nTerms);
+
+            metrics = struct();
+            metrics.rms = obj.computeRMS(coeffs);
+            metrics.pv = obj.computePV();
+            metrics.strehl = obj.computeStrehl();
+            metrics.residualRMS = obj.zernikeResidual(nTerms);
+            metrics.nTerms = nTerms;
+            metrics.coeffs = coeffs;
+        end
+
+        % -----------------------------------------------------------------
+        % Visualization
+        % -----------------------------------------------------------------
+
+        function plotWavefront(obj, varargin)
+            % plotWavefront - Display 2D wavefront phase map
+            %
+            %   wf.plotWavefront()
+            %   wf.plotWavefront('units', 'waves')  % show in wavelength units
+
+            parseargs = inputParser();
+            addParameter(parseargs, 'units', 'rad');
+            parse(parseargs, varargin{:});
+
+            phi = obj.getPhase();
+
+            figure;
+            imagesc(phi);
+            colorbar;
+            axis square;
+            colormap('hsv');
+            caxis([-pi, pi]);
+
+            if strcmp(parseargs.Results.units, 'waves')
+                phi_waves = phi / (2*pi);
+                imagesc(phi_waves);
+                colorbar;
+                caxis([-0.5, 0.5]);
+                ylabel('Phase [waves]');
+            else
+                ylabel('Phase [rad]');
+            end
+
+            xlabel('x'); ylabel('y');
+            title('Wavefront Phase');
+        end
+
+        function plotIntensity(obj)
+            % plotIntensity - Display 2D intensity map
+
+            I = obj.getIntensity();
+
+            figure;
+            imagesc(I);
+            colorbar;
+            axis square;
+            colormap('hot');
+            xlabel('x'); ylabel('y');
+            title('Intensity |E|^2');
+        end
+
+        function plotZernikeCoeffs(obj, coeffs)
+            % plotZernikeCoeffs - Bar chart of Zernike coefficients
+            %
+            %   wf.plotZernikeCoeffs(coeffs);
+
+            n = length(coeffs);
+            names = arrayfun(@(i) ZernikeUtils.zernikeName(i), 1:n, 'UniformOutput', false);
+
+            figure;
+            bar(1:n, coeffs);
+            set(gca, 'XTick', 1:n);
+            set(gca, 'XTickLabel', names, 'XTickLabelRotation', 60);
+            ylabel('Coefficient [rad]');
+            title('Zernike Decomposition');
+            grid on;
+        end
+
+        function plotPhaseSlice(obj, plane, idx)
+            % plotPhaseSlice - 1D phase cross-section
+            %
+            %   wf.plotPhaseSlice('x', Ny/2)   % horizontal slice at center
+            %   wf.plotPhaseSlice('y', Nx/2)   % vertical slice at center
+
+            phi = obj.getPhase();
+
+            if strcmpi(plane, 'x')
+                slice = phi(idx, :);
+                x = (-obj.Nx/2:obj.Nx/2-1) * obj.dx;
+                xlabel_str = 'x [m]';
+            else
+                slice = phi(:, idx)';
+                x = (-obj.Ny/2:obj.Ny/2-1) * obj.dy;
+                xlabel_str = 'y [m]';
+            end
+
+            figure;
+            plot(x, slice);
+            xlabel(xlabel_str);
+            ylabel('Phase [rad]');
+            title(sprintf('Phase Slice (%s=%d)', plane, idx));
+            grid on;
+        end
+    end
+end

--- a/src/visualization/ZernikeUtils.m
+++ b/src/visualization/ZernikeUtils.m
@@ -1,0 +1,221 @@
+classdef ZernikeUtils
+    % ZernikeUtils - Static Zernike polynomial utilities (Noll indexing)
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Usage:
+    %   Z = ZernikeUtils.zernike(n, rho, theta)   % compute Z_n
+    %   name = ZernikeUtils.zernikeName(n)         % get name string
+    %   M = ZernikeUtils.zernikeMatrix(rho, theta, N) % build design matrix
+    %
+    % Reference: Noll, R. J. (1976). Zernike polynomials and atmospheric turbulence.
+    %   J. Opt. Soc. Am., 66(3), 207-211.
+
+    methods (Static)
+        function Z = zernike(n, rho, theta)
+            % zernike - Compute Noll Zernike polynomial Z_n(rho, theta)
+            %
+            % Parameters:
+            %   n     - Zernike index (Noll order, 1-based)
+            %   rho   - radial coordinate [0, 1] (normalized)
+            %   theta - azimuthal angle [rad]
+            %
+            % Returns:
+            %   Z     - Zernike polynomial value(s)
+
+            % Clamp rho to [0, 1] range
+            rho = max(0, min(1, rho));
+
+            switch n
+                case 1
+                    % Z1: Piston (constant)
+                    Z = ones(size(rho));
+                case 2
+                    % Z2: Tilt X
+                    Z = 2 * rho .* cos(theta);
+                case 3
+                    % Z3: Tilt Y
+                    Z = 2 * rho .* sin(theta);
+                case 4
+                    % Z4: Defocus
+                    Z = sqrt(3) .* (2 * rho.^2 - 1);
+                case 5
+                    % Z5: Astigmatism 0 degrees
+                    Z = sqrt(6) * rho.^2 .* cos(2 * theta);
+                case 6
+                    % Z6: Astigmatism 45 degrees
+                    Z = sqrt(6) * rho.^2 .* sin(2 * theta);
+                case 7
+                    % Z7: Coma X
+                    Z = sqrt(8) * (3 * rho.^2 - 2) .* rho .* cos(theta);
+                case 8
+                    % Z8: Coma Y
+                    Z = sqrt(8) * (3 * rho.^2 - 2) .* rho .* sin(theta);
+                case 9
+                    % Z9: Spherical aberration
+                    Z = sqrt(8) * (6 * rho.^4 - 6 * rho.^2 + 1);
+                case 10
+                    % Z10: Secondary astigmatism 0 deg
+                    Z = sqrt(10) * (4 * rho.^4 - 3 * rho.^2) .* cos(2 * theta);
+                case 11
+                    % Z11: Secondary astigmatism 45 deg
+                    Z = sqrt(10) * (4 * rho.^4 - 3 * rho.^2) .* sin(2 * theta);
+                case 12
+                    % Z12: Secondary coma X
+                    Z = sqrt(12) * (10 * rho.^6 - 12 * rho.^4 + 3 * rho.^2) .* rho .* cos(theta);
+                case 13
+                    % Z13: Secondary coma Y
+                    Z = sqrt(12) * (10 * rho.^6 - 12 * rho.^4 + 3 * rho.^2) .* rho .* sin(theta);
+                case 14
+                    % Z14: Secondary spherical
+                    Z = sqrt(12) * (20 * rho.^6 - 30 * rho.^4 + 12 * rho.^2 - 1);
+                case 15
+                    % Z15: Trefoil X
+                    Z = sqrt(12) * (5 * rho.^6 - 4 * rho.^4) .* cos(3 * theta);
+                case 16
+                    % Z16: Trefoil Y
+                    Z = sqrt(12) * (5 * rho.^6 - 4 * rho.^4) .* sin(3 * theta);
+                case 17
+                    % Z17: Secondary astigmatism 0 deg (higher)
+                    Z = sqrt(14) * (15 * rho.^8 - 20 * rho.^6 + 6 * rho.^4) .* cos(2 * theta);
+                case 18
+                    % Z18: Secondary astigmatism 45 deg (higher)
+                    Z = sqrt(14) * (15 * rho.^8 - 20 * rho.^6 + 6 * rho.^4) .* sin(2 * theta);
+                case 19
+                    % Z19: Tertiary coma X
+                    Z = sqrt(14) * (35 * rho.^8 - 60 * rho.^6 + 30 * rho.^4 - 4 * rho.^2) .* rho .* cos(theta);
+                case 20
+                    % Z20: Tertiary coma Y
+                    Z = sqrt(14) * (35 * rho.^8 - 60 * rho.^6 + 30 * rho.^4 - 4 * rho.^2) .* rho .* sin(theta);
+                case 21
+                    % Z21: Tertiary spherical
+                    Z = sqrt(14) * (70 * rho.^8 - 105 * rho.^6 + 42 * rho.^4 - 6 * rho.^2 + 1);
+                case 22
+                    % Z22: Quadrafoil X
+                    Z = sqrt(14) * (21 * rho.^8 - 14 * rho.^6 + 4 * rho.^4) .* cos(4 * theta);
+                case 23
+                    % Z23: Quadrafoil Y
+                    Z = sqrt(14) * (21 * rho.^8 - 14 * rho.^6 + 4 * rho.^4) .* sin(4 * theta);
+                case 24
+                    % Z24: Secondary trefoil X
+                    Z = sqrt(16) * (56 * rho.^10 - 84 * rho.^8 + 36 * rho.^6 - 4 * rho.^4) .* cos(3 * theta);
+                case 25
+                    % Z25: Secondary trefoil Y
+                    Z = sqrt(16) * (56 * rho.^10 - 84 * rho.^8 + 36 * rho.^6 - 4 * rho.^4) .* sin(3 * theta);
+                case 26
+                    % Z26: Quaternary astigmatism 0 deg
+                    Z = sqrt(16) * (28 * rho.^10 - 42 * rho.^8 + 18 * rho.^6 - 2 * rho.^4) .* cos(2 * theta);
+                case 27
+                    % Z27: Quaternary astigmatism 45 deg
+                    Z = sqrt(16) * (28 * rho.^10 - 42 * rho.^8 + 18 * rho.^6 - 2 * rho.^4) .* sin(2 * theta);
+                case 28
+                    % Z28: Quaternary coma X
+                    Z = sqrt(16) * (126 * rho.^12 - 252 * rho.^10 + 168 * rho.^8 - 48 * rho.^6 + 5 * rho.^4) .* rho .* cos(theta);
+                case 29
+                    % Z29: Quaternary coma Y
+                    Z = sqrt(16) * (126 * rho.^12 - 252 * rho.^10 + 168 * rho.^8 - 48 * rho.^6 + 5 * rho.^4) .* rho .* sin(theta);
+                case 30
+                    % Z30: Quaternary spherical
+                    Z = sqrt(16) * (252 * rho.^12 - 504 * rho.^10 + 378 * rho.^8 - 144 * rho.^6 + 24 * rho.^4 - 1);
+                case 31
+                    % Z31: Pentafoil X
+                    Z = sqrt(16) * (126 * rho.^12 - 180 * rho.^10 + 90 * rho.^8 - 20 * rho.^6 + 5 * rho.^4) .* cos(5 * theta);
+                case 32
+                    % Z32: Pentafoil Y
+                    Z = sqrt(16) * (126 * rho.^12 - 180 * rho.^10 + 90 * rho.^8 - 20 * rho.^6 + 5 * rho.^4) .* sin(5 * theta);
+                case 33
+                    % Z33: Secondary trefoil X (higher)
+                    Z = sqrt(18) * (210 * rho.^12 - 378 * rho.^10 + 210 * rho.^8 - 45 * rho.^6 + 4 * rho.^4) .* cos(3 * theta);
+                case 34
+                    % Z34: Secondary trefoil Y (higher)
+                    Z = sqrt(18) * (210 * rho.^12 - 378 * rho.^10 + 210 * rho.^8 - 45 * rho.^6 + 4 * rho.^4) .* sin(3 * theta);
+                case 35
+                    % Z35: Secondary quadrafoil X
+                    Z = sqrt(18) * (495 * rho.^14 - 990 * rho.^12 + 693 * rho.^10 - 220 * rho.^8 + 30 * rho.^6 - 2 * rho.^4) .* cos(4 * theta);
+                case 36
+                    % Z36: Secondary quadrafoil Y
+                    Z = sqrt(18) * (495 * rho.^14 - 990 * rho.^12 + 693 * rho.^10 - 220 * rho.^8 + 30 * rho.^6 - 2 * rho.^4) .* sin(4 * theta);
+                otherwise
+                    error('ZernikeUtils:invalidIndex', ...
+                        'Zernike index n must be 1-36, got %d', n);
+            end
+        end
+
+        function name = zernikeName(n)
+            % zernikeName - Return the name string for Zernike index n (Noll order)
+
+            names = {
+                'Piston', ...
+                'Tilt X', ...
+                'Tilt Y', ...
+                'Defocus', ...
+                'Astigmatism 0°', ...
+                'Astigmatism 45°', ...
+                'Coma X', ...
+                'Coma Y', ...
+                'Spherical', ...
+                'Secondary Astigmatism 0°', ...
+                'Secondary Astigmatism 45°', ...
+                'Secondary Coma X', ...
+                'Secondary Coma Y', ...
+                'Secondary Spherical', ...
+                'Trefoil X', ...
+                'Trefoil Y', ...
+                'Secondary Astigmatism 0° (high)', ...
+                'Secondary Astigmatism 45° (high)', ...
+                'Tertiary Coma X', ...
+                'Tertiary Coma Y', ...
+                'Tertiary Spherical', ...
+                'Quadrafoil X', ...
+                'Quadrafoil Y', ...
+                'Secondary Trefoil X', ...
+                'Secondary Trefoil Y', ...
+                'Quaternary Astigmatism 0°', ...
+                'Quaternary Astigmatism 45°', ...
+                'Quaternary Coma X', ...
+                'Quaternary Coma Y', ...
+                'Quaternary Spherical', ...
+                'Pentafoil X', ...
+                'Pentafoil Y', ...
+                'Secondary Trefoil X (high)', ...
+                'Secondary Trefoil Y (high)', ...
+                'Secondary Quadrafoil X', ...
+                'Secondary Quadrafoil Y'
+            };
+
+            if n < 1 || n > 36
+                error('ZernikeUtils:invalidIndex', ...
+                    'Zernike index n must be 1-36, got %d', n);
+            end
+
+            name = names{n};
+        end
+
+        function M = zernikeMatrix(rho, theta, nTerms)
+            % zernikeMatrix - Build design matrix for Zernike fitting
+            %
+            % Parameters:
+            %   rho    - [Ny x Nx] radial coordinates (normalized 0-1)
+            %   theta  - [Ny x Nx] azimuthal coordinates (radians)
+            %   nTerms - number of Zernike terms to include (1-36)
+            %
+            % Returns:
+            %   M      - [Ny*Nx x nTerms] design matrix where M(:, n) = Z_n(rho, theta)
+
+            if nTerms < 1 || nTerms > 36
+                error('ZernikeUtils:invalidNTerms', ...
+                    'nTerms must be 1-36, got %d', nTerms);
+            end
+
+            % Reshape to column vectors for matrix construction
+            rho_col = rho(:);
+            theta_col = theta(:);
+            nPixels = length(rho_col);
+
+            % Build design matrix
+            M = zeros(nPixels, nTerms);
+            for n = 1:nTerms
+                M(:, n) = ZernikeUtils.zernike(n, rho_col, theta_col);
+            end
+        end
+    end
+end

--- a/tests/portable_runner.m
+++ b/tests/portable_runner.m
@@ -66,7 +66,8 @@ function totalFailed = portable_runner()
         'test_GaussianBeam_edge.m',
         'test_HankelHermite_edge.m',
         'test_HankelLaguerre_edge.m',
-        'test_RayTracing_extreme.m'
+        'test_RayTracing_extreme.m',
+        'test_Wavefront.m'
     };
     
     totalPassed = 0;

--- a/tests/test_Wavefront.m
+++ b/tests/test_Wavefront.m
@@ -1,0 +1,139 @@
+% test_Wavefront - Wavefront class tests
+% Compatible with GNU Octave and MATLAB
+%
+% Run with: octave --no-gui --eval "run('tests/test_Wavefront.m')"
+% Or: matlab -batch "run('tests/test_Wavefront.m')"
+
+testDir = fileparts(mfilename('fullpath'));
+repoRoot = fullfile(testDir, '..');
+addpath(fullfile(repoRoot, 'src', 'beams'));
+addpath(fullfile(repoRoot, 'src', 'parameters'));
+addpath(fullfile(repoRoot, 'src', 'computation'));
+addpath(fullfile(repoRoot, 'src', 'propagation', 'field'));
+addpath(fullfile(repoRoot, 'src', 'propagation', 'rays'));
+addpath(fullfile(repoRoot, 'src', 'visualization'));
+addpath(fullfile(repoRoot, 'ParaxialBeams'));
+addpath(fullfile(repoRoot, 'ParaxialBeams', 'Addons'));
+
+fprintf('=== Wavefront Test Suite ===\n\n');
+
+% Test 1: Basic constructor
+fprintf('Test 1: Constructor\n');
+E = ones(256, 256) + 1i*ones(256, 256);
+lambda = 632.8e-9;
+wf = Wavefront(E, lambda);
+assert(~isempty(wf.Field), 'Field should be stored');
+assert(wf.Lambda == lambda, 'Lambda should be stored');
+assert(wf.Nx == 256, 'Nx should be 256');
+assert(wf.Ny == 256, 'Ny should be 256');
+fprintf('  PASS: Constructor works\n\n');
+
+% Test 2: Get Intensity
+fprintf('Test 2: getIntensity\n');
+I = wf.getIntensity();
+assert(size(I) == [256, 256], 'Intensity size mismatch');
+assert(all(real(I(:)) >= 0), 'Intensity should be non-negative');
+fprintf('  PASS: getIntensity returns |E|^2\n\n');
+
+% Test 3: Get Phase
+fprintf('Test 3: getPhase\n');
+phi = wf.getPhase();
+assert(size(phi) == [256, 256], 'Phase size mismatch');
+assert(all(phi(:) >= -pi - 1e-10 & phi(:) <= pi + 1e-10), ...
+    'Phase should be in [-pi, pi]');
+fprintf('  PASS: getPhase returns wrapped phase\n\n');
+
+% Test 4: Zernike Z1 = 1 (Piston)
+fprintf('Test 4: Zernike Z1 (Piston)\n');
+rho = 0.5 * ones(10, 10);
+theta = zeros(10, 10);
+Z1 = ZernikeUtils.zernike(1, rho, theta);
+assert(all(abs(Z1(:) - 1) < 1e-10), 'Z1 should be 1');
+fprintf('  PASS: Z1 = 1 (Piston)\n\n');
+
+% Test 5: Zernike Z2 (Tilt X) formula
+fprintf('Test 5: Zernike Z2 (Tilt X)\n');
+rho = ones(10, 10);
+theta = zeros(10, 10);  % cos(0) = 1
+Z2 = ZernikeUtils.zernike(2, rho, theta);
+expected = 2 * 1 * 1;  % 2*rho*cos(theta) = 2*1*1
+assert(all(abs(Z2(:) - expected) < 1e-10), 'Z2 should be 2');
+fprintf('  PASS: Z2 = 2*rho*cos(theta)\n\n');
+
+% Test 6: Zernike Z4 (Defocus) formula
+fprintf('Test 6: Zernike Z4 (Defocus)\n');
+rho = ones(10, 10);
+theta = zeros(10, 10);
+Z4 = ZernikeUtils.zernike(4, rho, theta);
+expected = sqrt(3) * (2*1 - 1);  % sqrt(3)*(2*rho^2 - 1)
+assert(all(abs(Z4(:) - expected) < 1e-10), 'Z4 should be sqrt(3)');
+fprintf('  PASS: Z4 = sqrt(3)*(2*rho^2 - 1)\n\n');
+
+% Test 7: Zernike name lookup
+fprintf('Test 7: Zernike names\n');
+assert(strcmp(ZernikeUtils.zernikeName(1), 'Piston'), 'Z1 name');
+assert(strcmp(ZernikeUtils.zernikeName(2), 'Tilt X'), 'Z2 name');
+assert(strcmp(ZernikeUtils.zernikeName(4), 'Defocus'), 'Z4 name');
+fprintf('  PASS: Zernike names correct\n\n');
+
+% Test 8: Gaussian beam at waist (planar wavefront)
+fprintf('Test 8: Gaussian beam at waist - planar wavefront\n');
+beam = BeamFactory.create('gaussian', 100e-6, 632.8e-9);
+grid = GridUtils(256, 256, 1e-3, 1e-3);
+[X, Y] = grid.create2DGrid();
+E = beam.opticalField(X, Y, 0);  % z=0: planar wavefront
+wf_gauss = Wavefront(E, 632.8e-9, grid);
+coeffs = wf_gauss.fitZernike(36);
+% At waist (z=0), wavefront should be nearly flat (all coefficients small)
+% Piston term should be ~0 for ideal planar wavefront at reference
+assert(all(abs(coeffs) < 0.5), 'All Zernike terms should be small for planar wavefront');
+fprintf('  PASS: Gaussian at waist gives nearly planar wavefront\n\n');
+
+% Test 9: Round-trip fit -> reconstruct
+fprintf('Test 9: Round-trip fit/reconstruct residual\n');
+% Create test grid
+Nx = 50; Ny = 50;
+dx = 1e-3/Nx; dy = 1e-3/Ny;
+[X, Y] = meshgrid((-Nx/2:Nx/2-1)*dx, (-Ny/2:Ny/2-1)*dy);
+maxR = min(1e-3/2, 1e-3/2);
+rho_test = min(1, sqrt(X.^2 + Y.^2) / maxR);  % normalized to <= 1
+theta_test = atan2(Y, X);
+
+% Generate synthetic phase with known coefficients
+test_coeffs = zeros(36, 1);
+test_coeffs(4) = 0.5;  % Defocus only
+test_coeffs(7) = 0.3;  % Coma X
+phi_test = ZernikeUtils.zernikeMatrix(rho_test, theta_test, 36) * test_coeffs;
+phi_test = reshape(phi_test, Ny, Nx);
+
+wf_test = Wavefront(exp(1i * phi_test), 632.8e-9);
+% Use same grid for the wavefront
+wf_test.dx = dx; wf_test.dy = dy;
+wf_test.Dx = 1e-3; wf_test.Dy = 1e-3;
+
+residual = wf_test.zernikeResidual(36);
+assert(residual < 0.1, sprintf('Residual should be small, got %e', residual));
+fprintf('  PASS: Round-trip residual < 0.1\n\n');
+
+% Test 10: RMS and PV calculations
+fprintf('Test 10: RMS and PV calculations\n');
+phi_flat = zeros(256, 256);
+phi_flat(:) = 0.5;
+wf_flat = Wavefront(exp(1i * phi_flat), 632.8e-9);
+rms = wf_flat.computeRMS();
+pv = wf_flat.computePV();
+assert(abs(rms - 0.5) < 1e-10, sprintf('RMS should be 0.5, got %f', rms));
+assert(abs(pv) < 1e-10, sprintf('PV should be 0 for constant phase, got %f', pv));
+fprintf('  PASS: RMS and PV correct for constant phase\n\n');
+
+% Test 11: Strehl calculation
+fprintf('Test 11: Strehl calculation\n');
+sigma = 632.8e-9 / 10;  % lambda/10
+wf_strehl = Wavefront(exp(1i * sigma * randn(256,256)), 632.8e-9);
+strehl = wf_strehl.computeStrehl();
+expected_strehl = exp(-(2 * pi * sigma / 632.8e-9)^2);
+assert(abs(strehl - expected_strehl) < 0.01, ...
+    sprintf('Strehl should be ~%.3f, got %.3f', expected_strehl, strehl));
+fprintf('  PASS: Strehl approx exp(-(2pi*sigma/lambda)^2)\n\n');
+
+fprintf('=== All Tests Passed ===\n');


### PR DESCRIPTION
## Summary
- Created +paraxial/ directory structure with namespaced classes organized into subpackages: +beams/, +parameters/, +propagation/+field/, +propagation/+rays/, +computation/, +visualization/
- Added +paraxial/init.m convenience initializer
- Updated setpaths.m for dual-path mode (src/ + +paraxial/)

## Motivation
First step of Post-Merge Track 3: +paraxial package migration. Dual-path approach maintains backward compatibility while providing modern namespaced classes.