### PR TITLE
feat(paraxial): add +paraxial package with namespaced classes

### DIFF
--- a/+paraxial/+beams/ElegantHermiteBeam.m
+++ b/+paraxial/+beams/ElegantHermiteBeam.m
@@ -1,0 +1,173 @@
+classdef ElegantHermiteBeam < ParaxialBeam
+    % ElegantHermiteBeam - Elegant Hermite-Gaussian beam implementation
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Constructor (Phase 3 API):
+    %   beam = ElegantHermiteBeam(w0, lambda, n, m)
+    %
+    % Usage:
+    %   field = beam.opticalField(X, Y, z)    % complex field on Cartesian grid
+    %   params = beam.getParameters(z)         % GaussianParameters at z
+    %   name   = beam.beamName()               % e.g. 'elegant_hermite_2_0'
+    %
+    % Mathematical differences from standard HermiteBeam:
+    %
+    %   Standard HG: H_n(sqrt(2)*x/w(z))    -- real argument, waist scaling
+    %   Elegant HG:  H_n(sqrt(alpha(z))*x)   -- complex argument, alpha scaling
+    %
+    % where alpha(z) = i*k / (2*q(z)), q(z) = z + i*z_R (complex beam parameter).
+    %
+    % Full field definition (elegant Hermite-Gaussian, EHG_{nm}):
+    %
+    %   u_{nm}(x,y,z) = H_n(sqrt(alpha)*x) * H_m(sqrt(alpha)*y)
+    %                   * u_0(r,z) * exp(i*(n+m)*psi(z))
+    %
+    % Physical consequence: because alpha is complex, the Hermite polynomials
+    % evaluated at complex arguments produce amplitude AND phase modulation
+    % simultaneously — the hallmark of the "elegant" variant.
+    %
+    % Reference: Siegman, "Lasers", University Science Books (1986), Ch. 17;
+    %            Siegman, J. Opt. Soc. Am. A 13, 952 (1996).
+
+    properties
+        InitialWaist    % Beam waist at z = 0 (m)
+        n               % Horizontal mode index
+        m               % Vertical mode index
+        OpticalField    % Legacy snapshot field compatibility
+    end
+
+    methods
+        function obj = ElegantHermiteBeam(arg1, arg2, varargin)
+            % Constructor
+            % Modern API:
+            %   ElegantHermiteBeam(w0, lambda, n, m)
+            %
+            % Legacy-compatible API:
+            %   ElegantHermiteBeam(X, Y, hermiteParams)
+
+            % Call superclass constructor first (MATLAB requirement)
+            obj = obj@ParaxialBeam();
+
+            % Determine parameters from input using static helper
+            [w0, lambda, n, m, legacyCoords, legacyZ] = ...
+                ElegantHermiteBeam.parseArgs(arg1, arg2, varargin{:});
+
+            % Initialize parent class state
+            if ~isempty(lambda)
+                obj.Lambda = lambda;
+                obj.k = 2 * pi / lambda;
+            end
+
+            % Initialize subclass state
+            obj.InitialWaist = w0;
+            obj.n = n;
+            obj.m = m;
+
+            if ~isempty(legacyCoords{1})
+                obj.OpticalField = obj.computeField(legacyCoords{1}, legacyCoords{2}, legacyZ);
+            else
+                obj.OpticalField = [];
+            end
+        end
+
+        % -----------------------------------------------------------------
+        % ParaxialBeam interface
+        % -----------------------------------------------------------------
+
+        function field = opticalField(obj, X, Y, z)
+            % opticalField - Complex optical field on Cartesian grid (X,Y) at depth z.
+            field = obj.computeField(X, Y, z);
+        end
+
+        function params = getParameters(obj, z)
+            % getParameters - GaussianParameters evaluated at axial position z.
+            params = GaussianParameters(z, obj.InitialWaist, obj.Lambda);
+        end
+
+        function name = beamName(obj)
+            % beamName - Returns identifier string, e.g. 'elegant_hermite_2_0'.
+            name = sprintf('elegant_hermite_%d_%d', obj.n, obj.m);
+        end
+    end
+
+    methods (Static)
+        function [w0, lambda, n, m, legacyCoords, legacyZ] = parseArgs(arg1, arg2, varargin)
+            % Static helper to parse constructor arguments
+            w0 = [];
+            lambda = [];
+            n = 0;
+            m = 0;
+            legacyCoords = {[], []};
+            legacyZ = 0;
+
+            if nargin < 2
+                return;
+            end
+
+            if nargin == 3 && (isa(varargin{1}, 'ElegantHermiteParameters') || isa(varargin{1}, 'HermiteParameters'))
+                % Legacy: ElegantHermiteBeam(X, Y, hermiteParams)
+                params = varargin{1};
+                lambda = params.Lambda;
+                w0 = params.InitialWaist;
+                n = params.n;
+                m = params.m;
+                legacyCoords{1} = arg1;
+                legacyCoords{2} = arg2;
+                legacyZ = params.zCoordinate;
+
+            elseif nargin >= 2
+                % Modern: ElegantHermiteBeam(w0, lambda, n, m)
+                w0 = arg1;
+                lambda = arg2;
+                if numel(varargin) >= 2
+                    n = varargin{1};
+                    m = varargin{2};
+                end
+            end
+        end
+    end
+
+    % -----------------------------------------------------------------
+    % Private helpers
+    % -----------------------------------------------------------------
+    methods (Access = private)
+        function field = computeField(obj, X, Y, z)
+            % Compute EHG_{nm} field at Cartesian grid (X,Y) and depth z.
+            %
+            % Key: sqrt(alpha) is complex, so H_n(sqrt(alpha)*x) is evaluated
+            % with a complex argument, encoding both amplitude and phase.
+            w0     = obj.InitialWaist;
+            lambda = obj.Lambda;
+            k      = obj.k;
+            zr     = pi * w0^2 / lambda;
+
+            w   = w0 * sqrt(1 + (z/zr)^2);
+            Rc  = z  * (1 + (zr/z)^2);
+            if z == 0, Rc = Inf; end
+            psi = atan2(z, zr);
+
+            % Gaussian carrier field u_0(r,z)
+            r          = sqrt(X.^2 + Y.^2);
+            amplitude  = (w0 ./ w) .* exp(-r.^2 ./ w.^2);
+            phase_z    = -1i * k * z;
+            phase_curv = 1i * k * r.^2 ./ (2 * Rc);
+            phase_curv(isinf(Rc)) = 0;
+            phase_gouy = -1i * psi;
+            carrier    = amplitude .* exp(phase_z + phase_curv + phase_gouy);
+
+            % Complex beam parameter: alpha(z) = i*k / (2*q(z))
+            q          = z + 1i * zr;
+            alpha      = 1i * k / (2 * q);
+            sqrt_alpha = sqrt(alpha);
+
+            % Hermite polynomials with complex argument
+            Hn = PolynomialUtils.hermitePoly(obj.n, sqrt_alpha .* X);
+            Hm = PolynomialUtils.hermitePoly(obj.m, sqrt_alpha .* Y);
+
+            % Modal Gouy phase shift: (n+m)*psi
+            phi_mode = (obj.n + obj.m) * psi;
+
+            field = Hn .* Hm .* exp(-1i * phi_mode) .* carrier;
+        end
+    end
+end

--- a/+paraxial/+beams/ElegantLaguerreBeam.m
+++ b/+paraxial/+beams/ElegantLaguerreBeam.m
@@ -1,0 +1,179 @@
+classdef ElegantLaguerreBeam < ParaxialBeam
+    % ElegantLaguerreBeam - Elegant Laguerre-Gaussian beam implementation
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Constructor (Phase 3 API):
+    %   beam = ElegantLaguerreBeam(w0, lambda, l, p)
+    %
+    % Usage:
+    %   field = beam.opticalField(X, Y, z)    % complex field on Cartesian grid
+    %   params = beam.getParameters(z)         % GaussianParameters at z
+    %   name   = beam.beamName()               % e.g. 'elegant_laguerre_2_1'
+    %
+    % Mathematical differences from standard LaguerreBeam:
+    %
+    %   Standard LG: amplitude = (sqrt(2)*r/w)^|l|,  poly_arg = 2*r^2/w^2
+    %   Elegant LG:  amplitude = (sqrt(alpha)*r)^|l|, poly_arg = alpha*r^2
+    %
+    % where alpha(z) = i*k / (2*q(z)), q(z) = z + i*z_R (complex beam parameter).
+    %
+    % Full field definition (elegant Laguerre-Gaussian, ELG_{lp}):
+    %
+    %   u_{lp}(r,theta,z) = (sqrt(alpha)*r)^|l| * L_p^|l|(alpha*r^2)
+    %                       * u_0(r,z) * exp(i*l*theta) * exp(i*(|l|+2p)*psi(z))
+    %
+    % Physical consequence: using the complex beam parameter alpha instead of
+    % the real waist w changes both the radial amplitude profile and the
+    % polynomial argument, producing the "elegant" amplitude-phase coupling.
+    %
+    % The class accepts Cartesian (X, Y) in opticalField and converts to polar
+    % internally. Stores only w0, lambda, l, p — no grid or field.
+    %
+    % Reference: Siegman, "Lasers", University Science Books (1986), Ch. 17;
+    %            Siegman, J. Opt. Soc. Am. A 13, 952 (1996).
+
+    properties
+        InitialWaist    % Beam waist at z = 0 (m)
+        l               % Topological charge (azimuthal index)
+        p               % Radial order
+        OpticalField    % Legacy snapshot field compatibility
+    end
+
+    methods
+        function obj = ElegantLaguerreBeam(arg1, arg2, varargin)
+            % Constructor
+            % Modern API:
+            %   ElegantLaguerreBeam(w0, lambda, l, p)
+            %
+            % Legacy-compatible API:
+            %   ElegantLaguerreBeam(R, Theta, laguerreParams)
+
+            % Call superclass constructor first (MATLAB requirement)
+            obj = obj@ParaxialBeam();
+
+            % Determine parameters from input using static helper
+            [w0, lambda, l, p, legacyCoords, legacyZ] = ...
+                ElegantLaguerreBeam.parseArgs(arg1, arg2, varargin{:});
+
+            % Initialize parent class state
+            if ~isempty(lambda)
+                obj.Lambda = lambda;
+                obj.k = 2 * pi / lambda;
+            end
+
+            % Initialize subclass state
+            obj.InitialWaist = w0;
+            obj.l = l;
+            obj.p = p;
+
+            if ~isempty(legacyCoords{1})
+                obj.OpticalField = obj.computeField(legacyCoords{1}, legacyCoords{2}, legacyZ);
+            else
+                obj.OpticalField = [];
+            end
+        end
+
+        % -----------------------------------------------------------------
+        % ParaxialBeam interface
+        % -----------------------------------------------------------------
+
+        function field = opticalField(obj, X, Y, z)
+            % opticalField - Complex optical field on Cartesian grid (X,Y) at depth z.
+            %
+            % Converts Cartesian to polar internally, then evaluates the ELG field.
+            [TH, R] = cart2pol(X, Y);
+            field   = obj.computeField(R, TH, z);
+        end
+
+        function params = getParameters(obj, z)
+            % getParameters - GaussianParameters evaluated at axial position z.
+            params = GaussianParameters(z, obj.InitialWaist, obj.Lambda);
+        end
+
+        function name = beamName(obj)
+            % beamName - Returns identifier string, e.g. 'elegant_laguerre_2_1'.
+            name = sprintf('elegant_laguerre_%d_%d', obj.l, obj.p);
+        end
+    end
+
+    methods (Static)
+        function [w0, lambda, l, p, legacyCoords, legacyZ] = parseArgs(arg1, arg2, varargin)
+            % Static helper to parse constructor arguments
+            w0 = [];
+            lambda = [];
+            l = 0;
+            p = 0;
+            legacyCoords = {[], []};
+            legacyZ = 0;
+
+            if nargin < 2
+                return;
+            end
+
+            if nargin == 3 && (isa(varargin{1}, 'ElegantLaguerreParameters') || isa(varargin{1}, 'LaguerreParameters'))
+                % Legacy: ElegantLaguerreBeam(R, Theta, laguerreParams)
+                params = varargin{1};
+                lambda = params.Lambda;
+                w0 = params.InitialWaist;
+                l = params.l;
+                p = params.p;
+                legacyCoords{1} = arg1;
+                legacyCoords{2} = arg2;
+                legacyZ = params.zCoordinate;
+
+            elseif nargin >= 2
+                % Modern: ElegantLaguerreBeam(w0, lambda, l, p)
+                w0 = arg1;
+                lambda = arg2;
+                if numel(varargin) >= 2
+                    l = varargin{1};
+                    p = varargin{2};
+                end
+            end
+        end
+    end
+
+    % -----------------------------------------------------------------
+    % Private helpers
+    % -----------------------------------------------------------------
+    methods (Access = private)
+        function field = computeField(obj, r, theta, z)
+            % Compute ELG_{lp} field from polar grids (r, theta) and depth z.
+            w0     = obj.InitialWaist;
+            lambda = obj.Lambda;
+            k      = obj.k;
+            l      = obj.l;
+            p      = obj.p;
+            zr     = pi * w0^2 / lambda;
+
+            w   = w0 * sqrt(1 + (z/zr)^2);
+            Rc  = z  * (1 + (zr/z)^2);
+            if z == 0, Rc = Inf; end
+            psi = atan2(z, zr);
+
+            % Gaussian carrier field u_0(r,z)
+            amplitude  = (w0 ./ w) .* exp(-r.^2 ./ w.^2);
+            phase_z    = -1i * k * z;
+            phase_curv = 1i * k * r.^2 ./ (2 * Rc);
+            phase_curv(isinf(Rc)) = 0;
+            phase_gouy = -1i * psi;
+            carrier    = amplitude .* exp(phase_z + phase_curv + phase_gouy);
+
+            % Complex beam parameter: alpha(z) = i*k / (2*q(z))
+            q         = z + 1i * zr;
+            alpha_val = 1i * k / (2 * q);
+
+            % Polynomial argument: alpha*r^2  (complex, unlike 2*r^2/w^2 in standard LG)
+            Lpl = PolynomialUtils.associatedLaguerre(p, l, alpha_val .* r.^2);
+
+            % Radial amplitude: (sqrt(alpha)*r)^|l|  -- note: alpha is complex
+            amp_el = (sqrt(alpha_val) .* r).^abs(l);
+
+            % Modal Gouy phase shift: (|l|+2p)*psi
+            phi_mode = (abs(l) + 2*p) * psi;
+
+            field = amp_el .* Lpl .* exp(1i * l * theta) ...
+                    .* exp(-1i * phi_mode) .* carrier;
+        end
+    end
+end

--- a/+paraxial/+beams/GaussianBeam.m
+++ b/+paraxial/+beams/GaussianBeam.m
@@ -1,0 +1,165 @@
+classdef GaussianBeam < ParaxialBeam
+    % GaussianBeam - Scalar optical field for a fundamental Gaussian beam
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Constructor (Phase 3 API):
+    %   beam = GaussianBeam(w0, lambda)
+    %
+    % Usage:
+    %   field = beam.opticalField(X, Y, z)    % complex field on Cartesian grid
+    %   params = beam.getParameters(z)         % GaussianParameters at z
+    %   name   = beam.beamName()               % 'gaussian'
+    %
+    % The beam stores only the physical parameters w0 and lambda. All grid
+    % quantities (field, waist at z, radius, Gouy phase) are computed on
+    % demand by opticalField(X, Y, z). This makes the object stateless with
+    % respect to propagation distance.
+
+    properties
+        InitialWaist    % Beam waist at z = 0 (m)
+        OpticalField    % Legacy snapshot field compatibility
+    end
+
+    methods
+        function obj = GaussianBeam(arg1, arg2, varargin)
+            % Constructor
+            % Modern API:
+            %   GaussianBeam(w0, lambda)
+            %
+            % Legacy-compatible APIs:
+            %   GaussianBeam(R, gaussianParams)
+            %   GaussianBeam(X, Y, gaussianParams)
+
+            % Call superclass constructor first (MATLAB requirement - MUST be
+            % unconditional; cannot be inside a conditional or expression)
+            obj = obj@ParaxialBeam();
+
+            % Handle empty constructor — return early after minimal init
+            if nargin == 0
+                obj.InitialWaist = [];
+                obj.OpticalField = [];
+                return;
+            end
+
+            % Determine parameters from input using static helper
+            [w0, lambda, legacyCoords, legacyZ] = GaussianBeam.parseArgs(arg1, arg2, varargin{:});
+
+            % Initialize parent class state
+            if ~isempty(lambda)
+                obj.Lambda = lambda;
+                obj.k = 2 * pi / lambda;
+            end
+
+            % Initialize subclass state
+            obj.InitialWaist = w0;
+
+            if ~isempty(legacyCoords{1})
+                obj.OpticalField = obj.opticalFieldLegacy(legacyCoords{1}, legacyCoords{2}, legacyZ);
+            else
+                obj.OpticalField = [];
+            end
+        end
+
+        % -----------------------------------------------------------------
+        % ParaxialBeam interface
+        % -----------------------------------------------------------------
+
+        function field = opticalField(obj, X, Y, z)
+            % opticalField - Complex optical field on Cartesian grid (X,Y) at depth z.
+            %
+            % Field formula (fundamental Gaussian TEM_{00}):
+            %
+            %   u(r,z) = (w0/w) * exp(-r^2/w^2)
+            %            * exp(-i*k*z) * exp(i*k*r^2/(2R)) * exp(-i*psi)
+            %
+            % where:
+            %   r   = sqrt(x^2 + y^2)    radial distance (m)
+            %   w   = w(z)                beam waist at z
+            %   R   = R(z)                radius of curvature (Inf at z=0)
+            %   psi = psi(z) = arctan(z/zR)   Gouy phase
+
+            w0     = obj.InitialWaist;
+            lambda = obj.Lambda;
+            k      = obj.k;
+            zr     = pi * w0^2 / lambda;
+
+            w   = w0 * sqrt(1 + (z ./ zr).^2);
+            Rc  = z  .* (1 + (zr ./ z).^2);
+            if isscalar(z) && z == 0
+                Rc = Inf;
+            else
+                Rc(z == 0) = Inf;
+            end
+            psi = atan2(z, zr);
+
+            r          = sqrt(X.^2 + Y.^2);
+            amplitude  = (w0 ./ w) .* exp(-r.^2 ./ w.^2);
+            phase_z    = -1i * k .* z;
+            phase_curv = 1i * k .* r.^2 ./ (2 .* Rc);
+            phase_curv(isinf(Rc)) = 0;
+            phase_gouy = -1i * psi;
+
+            field = amplitude .* exp(phase_z + phase_curv + phase_gouy);
+        end
+
+        function params = getParameters(obj, z)
+            % getParameters - GaussianParameters evaluated at axial position z.
+            params = GaussianParameters(z, obj.InitialWaist, obj.Lambda);
+        end
+
+        function name = beamName(obj)
+            name = 'gaussian';
+        end
+    end
+
+    methods (Static)
+        function [w0, lambda, legacyCoords, legacyZ] = parseArgs(arg1, arg2, varargin)
+            % Static helper to parse constructor arguments
+            % Avoids calling instance method before constructor completes
+            w0 = [];
+            lambda = [];
+            legacyCoords = {[], []};
+            legacyZ = 0;
+
+            if nargin < 2
+                return;
+            end
+
+            if nargin == 3 && isa(varargin{1}, 'GaussianParameters')
+                % GaussianBeam(X, Y, gaussianParams)
+                params = varargin{1};
+                lambda = params.Lambda;
+                w0 = params.InitialWaist;
+                legacyCoords{1} = arg1;
+                legacyCoords{2} = arg2;
+                legacyZ = params.zCoordinate;
+
+            elseif nargin == 2 && isa(arg2, 'GaussianParameters')
+                % GaussianBeam(R, gaussianParams)
+                params = arg2;
+                lambda = params.Lambda;
+                w0 = params.InitialWaist;
+                legacyCoords{1} = arg1;
+                legacyZ = params.zCoordinate;
+
+            elseif nargin >= 2
+                % Modern: GaussianBeam(w0, lambda)
+                w0 = arg1;
+                lambda = arg2;
+            end
+        end
+    end
+
+    methods (Access = private)
+        function field = opticalFieldLegacy(obj, coordA, coordB, z)
+            if isempty(coordB)
+                X = coordA;
+                Y = zeros(size(coordA));
+            else
+                X = coordA;
+                Y = coordB;
+            end
+            field = obj.opticalField(X, Y, z);
+        end
+    end
+end

--- a/+paraxial/+beams/HankelHermite.m
+++ b/+paraxial/+beams/HankelHermite.m
@@ -1,0 +1,254 @@
+classdef HankelHermite < ParaxialBeam
+    % HankelHermite - Hankel-type Hermite-Gaussian beam field
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Constructor (Phase 3 API):
+    %   beam = HankelHermite(w0, lambda, n, m, hankelType)
+    %
+    % Usage:
+    %   field = beam.opticalField(X, Y, z)    % complex field on Cartesian grid
+    %   params = beam.getParameters(z)         % GaussianParameters at z
+    %   name   = beam.beamName()               % e.g. 'hankel11_hermite_3_2'
+    %
+    % -------------------------------------------------------------------------
+    % Theoretical Context
+    % -------------------------------------------------------------------------
+    % Hankel-Hermite beams are constructed from two independent series
+    % solutions of the Hermite differential equation:
+    %   HG  - standard Hermite-Gauss (even/odd parity depending on mode)
+    %   NHG - complementary solution with opposite parity
+    %
+    % The four Hankel-Hermite types combine these independently in x and y:
+    %   H^(11) = (HG_x + i*NHG_x) * (HG_y + i*NHG_y) * carrier
+    %   H^(12) = (HG_x + i*NHG_x) * (HG_y - i*NHG_y) * carrier
+    %   H^(21) = (HG_x - i*NHG_x) * (HG_y + i*NHG_y) * carrier
+    %   H^(22) = (HG_x - i*NHG_x) * (HG_y - i*NHG_y) * carrier
+    %
+    % Legacy constructor (also supported):
+    %   HankelHermite(x, y, hermiteParameters, hankelType)
+    % Produces .OpticalField for legacy scripts.
+
+    properties
+        InitialWaist    % Beam waist at z = 0 (m)
+        n               % Hermite order in x
+        m               % Hermite order in y
+        HankelType      % 11, 12, 21, or 22
+        OpticalField    % Legacy snapshot field container
+    end
+
+    methods (Static)
+        function Rays = getPropagateCartesianRays(Rays, x, y, difr, HParametersZi, HParametersZ, HankelType)
+            tempdr = num2cell(difr);
+            [dx, dy, dz] = deal(tempdr{:});
+
+            totalRays = numel(Rays.xCoordinate);
+
+            for ray_index = 1:totalRays
+                xi = Rays.xCoordinate(ray_index) + (1 ./ Rays.zxSlope(ray_index)) * dz;
+                yi = Rays.yCoordinate(ray_index) + (1 ./ Rays.zySlope(ray_index)) * dz;
+                zi = Rays.zCoordinate(ray_index) + dz;
+
+                Rays.xCoordinate(ray_index) = xi;
+                Rays.yCoordinate(ray_index) = yi;
+                Rays.zCoordinate(ray_index) = zi;
+                Rays.hankelType(ray_index) = HankelType;
+
+                HHx = HankelHermite(x, yi, HParametersZi, HankelType);
+                HHy = HankelHermite(xi, y, HParametersZi, HankelType);
+                HHz = HankelHermite(xi, yi, HParametersZ, HankelType);
+
+                fx = unwrap(angle(HHx.OpticalField));
+                fy = unwrap(angle(HHy.OpticalField));
+                fz = unwrap(angle(HHz.OpticalField));
+
+                [zxSlope, zySlope, xySlope] = HankelHermite.gradientCartesian(fx, fy, fz, HParametersZi.k, dx, dy, dz, xi, yi, zi);
+                Rays.zxSlope(ray_index) = zxSlope;
+                Rays.zySlope(ray_index) = zySlope;
+                Rays.xySlope(ray_index) = xySlope;
+            end
+        end
+    end
+
+    methods
+        function obj = HankelHermite(w0, lambda, n, m, hankelType)
+            % Constructor
+            % w0:         initial beam waist at z = 0 (m)
+            % lambda:     wavelength (m)
+            % n:          Hermite order in x (default 0)
+            % m:          Hermite order in y (default 0)
+            % hankelType: 11, 12, 21, or 22 (default 11)
+            %
+            % Legacy constructor (also supported):
+            %   HankelHermite(x, y, hermiteParameters, hankelType)
+
+            obj = obj@ParaxialBeam();
+
+            if nargin == 0
+                obj.HankelType = 11;
+                obj.OpticalField = [];
+                return;
+            end
+
+            % Detect legacy API: 3rd arg is a HermiteParameters object
+            if nargin >= 3 && isa(n, 'HermiteParameters')
+                isLegacy = true;
+            else
+                isLegacy = false;
+            end
+
+            if isLegacy
+                % Legacy: HankelHermite(x, y, hermiteParams, hankelType)
+                % The 4th legacy arg maps to 'm' in this signature.
+                if nargin >= 4
+                    raw_hankelType = m;
+                else
+                    raw_hankelType = 11;
+                end
+                hankelType = raw_hankelType;
+            else
+                if nargin < 5, hankelType = 11; end
+                if nargin < 4, m = 0; end
+                if nargin < 3, n = 0; end
+            end
+
+            [w0, lambda, n, m, hankelType, legacyCoords, legacyZ] = ...
+                HankelHermite.parseArgs(w0, lambda, n, m, hankelType);
+
+            if ~isempty(lambda)
+                obj.Lambda = lambda;
+                obj.k = 2 * pi / lambda;
+            end
+
+            obj.InitialWaist = w0;
+            obj.n = n;
+            obj.m = m;
+            obj.HankelType = hankelType;
+
+            if ~isempty(legacyCoords{1})
+                obj.OpticalField = hankelHermiteField(legacyCoords{1}, legacyCoords{2}, ...
+                    w0, lambda, n, m, legacyZ, hankelType);
+            else
+                obj.OpticalField = [];
+            end
+        end
+
+        % -----------------------------------------------------------------
+        % ParaxialBeam interface
+        % -----------------------------------------------------------------
+
+        function field = opticalField(obj, X, Y, z)
+            field = hankelHermiteField(X, Y, obj.InitialWaist, obj.Lambda, ...
+                obj.n, obj.m, z, obj.HankelType);
+        end
+
+        function params = getParameters(obj, z)
+            params = GaussianParameters(z, obj.InitialWaist, obj.Lambda);
+        end
+
+        function name = beamName(obj)
+            name = sprintf('hankel%d_hermite_%d_%d', obj.HankelType, obj.n, obj.m);
+        end
+    end
+
+    methods (Static)
+        function [w0, lambda, n, m, hankelType, legacyCoords, legacyZ] = parseArgs(w0, lambda, n, m, hankelType)
+            legacyCoords = {[], []};
+            legacyZ = 0;
+
+            if nargin < 1
+                n = 0; m = 0; hankelType = 11;
+                return;
+            end
+
+            if nargin >= 3 && isa(n, 'HermiteParameters')
+                hermiteParams = n;
+                legacyCoords{1} = w0;       % x coordinate
+                legacyCoords{2} = lambda;   % y coordinate
+                legacyZ = hermiteParams.zCoordinate;
+                w0 = hermiteParams.InitialWaist;
+                lambda = hermiteParams.Lambda;
+                n = hermiteParams.n;
+                m = hermiteParams.m;
+                if nargin < 5, hankelType = 11; end
+            else
+                if nargin < 3, n = 0; end
+                if nargin < 4, m = 0; end
+                if nargin < 5, hankelType = 11; end
+            end
+        end
+    end
+
+    methods (Static, Access = private)
+        function [zxSlope, zySlope, xySlope] = gradientCartesian(fx, fy, fz, k, dx, dy, dz, x, y, z)
+            gx = gradient(fx) ./ dx;
+            gy = gradient(fy) ./ dy;
+            gz = gradient(fz) ./ dz + k;
+
+            nn = size(gx, 2);
+            idxZ = HankelHermite.clampIndex(floor(z / dz + 1), numel(gz));
+            idxX = HankelHermite.clampIndex(nn / 2 + 1 + floor(x / dx), numel(gx));
+            idxY = HankelHermite.clampIndex(nn / 2 + 1 + floor(y / dy), numel(gy));
+
+            zxSlope = gz(idxZ) / gx(idxX);
+            zySlope = gz(idxZ) / gy(idxY);
+            xySlope = gx(idxX) / gy(idxY);
+        end
+
+        function idx = clampIndex(raw, maxSize)
+            idx = floor(raw);
+            if idx < 1
+                idx = 1;
+            elseif idx > maxSize
+                idx = maxSize;
+            end
+        end
+    end
+end
+
+% -------------------------------------------------------------------------
+% Module-private helper (not a method — keeps the class definition clean)
+% -------------------------------------------------------------------------
+function field = hankelHermiteField(X, Y, w0, lambda, n, m, z, hankelType)
+    % hankelHermiteField - Compute Hankel-Hermite field at depth z.
+    %
+    % Uses both independent series solutions [HG, NHG] of the Hermite
+    % differential equation, obtained via HermiteParameters.getHermiteSolutions.
+
+    k  = 2*pi/lambda;
+    zr = pi * w0.^2 ./ lambda;
+
+    w   = w0 .* sqrt(1 + (z./zr).^2);
+    Rc  = z  .* (1 + (zr./z).^2);
+    Rc(z == 0) = Inf;
+    psi = atan2(z, zr);
+
+    % Gaussian carrier field u_0(r,z)
+    r          = sqrt(X.^2 + Y.^2);
+    amplitude  = (w0 ./ w) .* exp(-r.^2 ./ w.^2);
+    phase_z    = -1i .* k .* z;
+    phase_curv = 1i .* k .* r.^2 ./ (2 .* Rc);
+    phase_curv(isinf(Rc)) = 0;
+    phase_gouy = -1i .* psi;
+    carrier    = amplitude .* exp(phase_z + phase_curv + phase_gouy);
+
+    % Both Hermite solutions in x and y
+    [Hx, NHx] = HermiteParameters.getHermiteSolutions(n, (sqrt(2) ./ w) .* X);
+    [Hy, NHy] = HermiteParameters.getHermiteSolutions(m, (sqrt(2) ./ w) .* Y);
+
+    % Modal Gouy phase shift: (n+m)*psi
+    phi_mode = (n + m) * psi;
+
+    % Hankel combination
+    switch hankelType
+        case 11
+            field = (Hx + 1i * NHx) .* (Hy + 1i * NHy) .* exp(-1i * phi_mode) .* carrier;
+        case 12
+            field = (Hx + 1i * NHx) .* (Hy - 1i * NHy) .* exp(-1i * phi_mode) .* carrier;
+        case 21
+            field = (Hx - 1i * NHx) .* (Hy + 1i * NHy) .* exp(-1i * phi_mode) .* carrier;
+        case 22
+            field = (Hx - 1i * NHx) .* (Hy - 1i * NHy) .* exp(-1i * phi_mode) .* carrier;
+        otherwise
+            error('HankelHermite:invalidType', 'Unsupported Hankel type: %d. Use 11, 12, 21, or 22.', hankelType);
+    end
+end

--- a/+paraxial/+beams/HankelLaguerre.m
+++ b/+paraxial/+beams/HankelLaguerre.m
@@ -1,0 +1,346 @@
+classdef HankelLaguerre < ParaxialBeam
+    % HankelLaguerre - Hankel-type Laguerre-Gaussian beam field
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Constructor (Phase 3 API):
+    %   beam = HankelLaguerre(w0, lambda, l, p, hankelType)
+    %
+    % Usage:
+    %   field = beam.opticalField(X, Y, z)    % complex field on Cartesian grid
+    %   params = beam.getParameters(z)         % GaussianParameters at z
+    %   name   = beam.beamName()               % e.g. 'hankel1_laguerre_2_1'
+    %
+    % -------------------------------------------------------------------------
+    % Theoretical Context (Contexto Academico)
+    % -------------------------------------------------------------------------
+    % Hankel beams are specialized solutions to the paraxial wave equation
+    % that represent "conical" waves. Unlike standard LG modes, these beams
+    % possess a net radial energy flow, making them ideal for modelling
+    % diverging or converging wavefronts in complex media.
+    %
+    % Mathematical Definition:
+    % They are constructed through the superposition of a paraxial mode
+    % and its quadrature (Hilbert transform) companion:
+    %
+    %   H_{lp}^{(1,2)}(r, phi, z) = LG_{lp}(r, phi, z) +/- i * XLG_{lp}(r, phi, z)
+    %
+    % where XLG_{lp} is the Hilbert-transformed counterpart:
+    %   - Azimuthal phase: exp(-i*p*theta) instead of exp(i*l*theta)
+    %   - Radial/polynomial structure: same as LG_{lp}
+    %
+    % Physical Significance:
+    %   H^{(1)}: Outward propagating wave (away from axis) — analogous to H^(1)(kr)
+    %   H^{(2)}: Inward  propagating wave (towards axis)  — analogous to H^(2)(kr)
+    %
+    % Reference: Kotlyar et al., "Hankel-Bessel laser beams", J. Opt. Soc. Am. A.
+
+    properties
+        InitialWaist    % Beam waist at z = 0 (m)
+        l               % Topological charge (azimuthal index)
+        p               % Radial order
+        HankelType      % 1 = H^(1) outward, 2 = H^(2) inward
+        OpticalFieldLaguerre % Legacy compatibility field container
+    end
+
+    methods
+        function obj = HankelLaguerre(w0, lambda, l, p, hankelType, varargin)
+            % Constructor
+            % w0:         initial beam waist at z = 0 (m)
+            % lambda:     wavelength (m)
+            % l:          topological charge (default 0)
+            % p:          radial order (default 0)
+            % hankelType: 1 = H^(1) [default], 2 = H^(2)
+            %
+            % Legacy constructor (also supported):
+            %   HankelLaguerre(r, theta, laguerreParameters, hankelType)
+            % Produces .OpticalFieldLaguerre for legacy scripts.
+            %
+            % Note: uses varargin to capture the raw 4th argument in legacy calls,
+            % avoiding Octave parse errors when hankelType is not passed.
+
+            % Call superclass constructor first (MATLAB requirement)
+            obj = obj@ParaxialBeam();
+
+            % Detect legacy API by checking the type of the 3rd argument.
+            % Legacy: HankelLaguerre(r, theta, laguerreParams, hankelType)
+            %   — arg3 is a LaguerreParameters object
+            % Modern: HankelLaguerre(w0, lambda, l, p, hankelType)
+            %   — arg3 is numeric (topological charge) or empty
+            % Note: inputname(3) is empty when arg3 is a computed expression
+            % (e.g. LaguerreParameters(...)), so we rely on isa() directly.
+            if nargin >= 3 && isa(l, 'LaguerreParameters')
+                isLegacy = true;
+            else
+                isLegacy = false;
+            end
+
+            if isLegacy
+                % Legacy API: HankelLaguerre(r, theta, laguerreParams, hankelType)
+                % The 4th legacy arg maps to 'p' in this signature (not varargin).
+                if nargin >= 4
+                    raw_hankelType_arg = p;
+                else
+                    raw_hankelType_arg = 1;
+                end
+                % parseArgs expects hankelType defined; set from extracted value.
+                hankelType = raw_hankelType_arg;
+            else
+                % Modern API.
+                raw_hankelType_arg = [];
+                if nargin < 5, hankelType = 1; end
+                if nargin < 4, p = 0; end
+                if nargin < 3, l = 0; end
+            end
+
+            % Determine parameters from input using static helper
+            [w0_out, lambda_out, l_out, p_out, hankelType_out, legacyCoords, legacyZ] = ...
+                HankelLaguerre.parseArgs(w0, lambda, l, p, hankelType, raw_hankelType_arg);
+
+            % Initialize parent class state
+            if ~isempty(lambda_out)
+                obj.Lambda = lambda_out;
+                obj.k = 2 * pi / lambda_out;
+            end
+
+            % Initialize subclass state
+            obj.InitialWaist = w0_out;
+            obj.l = l_out;
+            obj.p = p_out;
+            obj.HankelType = hankelType_out;
+
+            if ~isempty(legacyCoords{1})
+                obj.OpticalFieldLaguerre = hankelField(legacyCoords{1}, legacyCoords{2}, ...
+                    w0_out, lambda_out, l_out, p_out, legacyZ, hankelType_out);
+            else
+                obj.OpticalFieldLaguerre = [];
+            end
+        end
+
+        % -----------------------------------------------------------------
+        % ParaxialBeam interface
+        % -----------------------------------------------------------------
+
+        function field = opticalField(obj, X, Y, z)
+            % opticalField - Complex optical field on Cartesian grid (X,Y) at depth z.
+            %
+            % Converts Cartesian to polar, then computes the Hankel superposition.
+            [TH, R] = cart2pol(X, Y);
+            field   = hankelField(R, TH, obj.InitialWaist, obj.Lambda, obj.l, obj.p, z, obj.HankelType);
+        end
+
+        function params = getParameters(obj, z)
+            % getParameters - GaussianParameters evaluated at axial position z.
+            params = GaussianParameters(z, obj.InitialWaist, obj.Lambda);
+        end
+
+        function name = beamName(obj)
+            % beamName - Returns identifier string, e.g. 'hankel1_laguerre_2_1'.
+            name = sprintf('hankel%d_laguerre_%d_%d', obj.HankelType, obj.l, obj.p);
+        end
+    end
+
+    methods (Static)
+        function [w0, lambda, l, p, hankelType, legacyCoords, legacyZ] = parseArgs(w0, lambda, l, p, hankelType, raw_hankelType_arg)
+            % Static helper to parse constructor arguments
+            % Detects legacy API: when l is a LaguerreParameters object
+            if nargin < 6, raw_hankelType_arg = []; end
+            legacyCoords = {[], []};
+            legacyZ = 0;
+
+            if nargin < 1
+                l = 0; p = 0; hankelType = 1;
+                return;
+            end
+
+            % Legacy path: HankelLaguerre(r, theta, laguerreParams, hankelType)
+            if nargin >= 3 && isa(l, 'LaguerreParameters')
+                laguerreParams = l;
+                legacyCoords{1} = w0;      % r coordinate
+                legacyCoords{2} = lambda;  % theta coordinate
+                legacyZ = laguerreParams.zCoordinate;
+                w0 = laguerreParams.InitialWaist;
+                lambda = laguerreParams.Lambda;
+                l = laguerreParams.l;
+                p = laguerreParams.p;
+                if ~isempty(raw_hankelType_arg)
+                    hankelType = raw_hankelType_arg;
+                else
+                    hankelType = 1;
+                end
+            else
+                % Modern path: HankelLaguerre(w0, lambda, l, p, hankelType)
+                if nargin < 3, l = 0; end
+                if nargin < 4, p = 0; end
+                if nargin < 5, hankelType = 1; end
+            end
+        end
+
+        function Rays = getPropagateCylindricalRays(Rays, TotalRays, r, th, difr, LParametersZi, LParametersZ, HankelType)
+            % getPropagateCylindricalRays - Legacy-compatible ray propagation API.
+            tempdr = num2cell(difr);
+            [dr, dtheta, dz] = deal(tempdr{:});
+
+            for point_index = 1:TotalRays
+                ri = Rays.rCoordinate(point_index) + (1 ./ Rays.zrSlope(point_index)) * dz;
+                thi = Rays.thetaCoordinate(point_index) + (1 ./ Rays.zthSlope(point_index)) * dz;
+                zi = Rays.zCoordinate(point_index) + dz;
+
+                rayHankelType = HankelType;
+                if (ri < 0) && (HankelType == 2)
+                    rayHankelType = 1;
+                    ri = abs(ri);
+                end
+
+                Rays.rCoordinate(point_index) = ri;
+                Rays.thetaCoordinate(point_index) = thi;
+                Rays.zCoordinate(point_index) = zi;
+                Rays.hankelType(point_index) = rayHankelType;
+
+                [xi, yi] = pol2cart(thi, ri);
+                if (HankelType == 2) && (rayHankelType == 1)
+                    xi = -xi;
+                    yi = -yi;
+                end
+                Rays.xCoordinate(point_index) = xi;
+                Rays.yCoordinate(point_index) = yi;
+
+                HLr = HankelLaguerre(r, thi, LParametersZi, rayHankelType);
+                HLth = HankelLaguerre(ri, th, LParametersZi, rayHankelType);
+                HLz = HankelLaguerre(ri, thi, LParametersZ, rayHankelType);
+
+                fr = unwrap(angle(HLr.OpticalFieldLaguerre));
+                fth = unwrap(angle(HLth.OpticalFieldLaguerre));
+                fz = unwrap(angle(HLz.OpticalFieldLaguerre));
+
+                [zrSlope, zthSlope, rthSlope] = HankelLaguerre.gradientCylindrical(fr, fth, fz, LParametersZi.k, dr, dtheta, dz, ri, thi, zi);
+                Rays.zrSlope(point_index) = zrSlope;
+                Rays.zthSlope(point_index) = zthSlope;
+                Rays.rthSlope(point_index) = rthSlope;
+            end
+        end
+    end
+
+    methods (Static, Access = private)
+        function [zrSlope, zthSlope, rthSlope] = gradientCylindrical(fr, ftheta, fz, k, dr, dtheta, dz, r, theta, z)
+            gr = gradient(fr) ./ dr;
+            gtheta = (1 ./ r) .* (gradient(ftheta) ./ dtheta);
+            gz = gradient(fz) ./ dz + k;
+
+            n = size(gr, 2);
+            idxZ = HankelLaguerre.clampIndex(floor(z / dz + 1), numel(gz));
+            idxR = HankelLaguerre.clampIndex(n / 2 + 1 + floor(r / dr), numel(gr));
+            idxTheta = HankelLaguerre.clampIndex(n / 2 + 1 + floor(theta / dtheta), numel(gtheta));
+
+            zrSlope = gz(idxZ) / gr(idxR);
+            zthSlope = gz(idxZ) / gtheta(idxTheta);
+            rthSlope = gr(idxR) / gtheta(idxTheta);
+        end
+
+        function idx = clampIndex(raw, maxSize)
+            idx = floor(raw);
+            if idx < 1
+                idx = 1;
+            elseif idx > maxSize
+                idx = maxSize;
+            end
+        end
+    end
+end
+
+% -------------------------------------------------------------------------
+% Module-private helper (not a method — keeps the class definition clean)
+% -------------------------------------------------------------------------
+function field = hankelField(r, theta, w0, lambda, l, p, z, hankelType)
+    % hankelField - Compute H^(1) or H^(2) Hankel-Laguerre field at depth z.
+    %
+    % Project phase convention (same as LaguerreBeam):
+    %   exp(-i*k*z) axial carrier.
+    % Therefore, total LG phase is:
+    %   Phi = -kz + (k*r^2)/(2R) + l*theta - (1+2p+|l|)*psi(z)
+    %
+    % Uses two independent solutions of the Laguerre differential equation:
+    %   LG  : L_p^|l|(x) — standard associated Laguerre polynomial
+    %   XLG : Y_p^|l|(x) — second solution (logarithmic + digamma series)
+    %
+    % H^(1) = LG + i*XLG   (outward propagating)
+    % H^(2) = LG - i*XLG   (inward propagating)
+    %
+    % The two solutions have different radial structure, producing genuinely
+    % different wavefront curvature and ray slopes for H^(1) vs H^(2).
+    %
+    % References:
+    %   - Allen92: L. Allen et al., Phys. Rev. A 45, 1992.
+    %   - Papi, "Hankel beams", Structured Light, Elsevier 2023.
+
+    k  = 2*pi/lambda;
+    zr = pi * w0.^2 ./ lambda;
+
+    w   = w0 .* sqrt(1 + (z./zr).^2);
+    Rc  = z  .* (1 + (zr./z).^2);
+    Rc(z == 0) = Inf;
+    gouy = atan2(z, zr);
+
+    % Gaussian carrier field u_0(r,z)
+    amplitude  = (w0 ./ w) .* exp(-r.^2 ./ w.^2);
+    phase_z    = -1i * k * z;
+    phase_curv = 1i * k * r.^2 ./ (2 * Rc);
+    phase_curv(isinf(Rc)) = 0;
+    phase_gouy = -1i * gouy;
+    carrier    = amplitude .* exp(phase_z + phase_curv + phase_gouy);
+
+    % Argument for radial polynomials
+    arg = 2 * r.^2 ./ w.^2;
+
+    % Standard LG amplitude: (sqrt(2)*r/w)^|l|
+    amp  = (sqrt(2) * r ./ w).^abs(l);
+
+    % Modal Gouy phase shift: (|l|+2p)*gouy
+    phi_mode = (abs(l) + 2*p) * gouy;
+
+    % --- LB field (first solution: standard Laguerre polynomial) ---
+    Lpl = PolynomialUtils.associatedLaguerre(p, l, arg);
+    LB_field = amp .* Lpl .* exp(1i * l * theta) .* exp(-1i * phi_mode) .* carrier;
+
+    % --- XLG field (second solution) ---
+    % Keep amplitude scaling CONSISTENT with LB:
+    %   both use the same Gaussian carrier and (sqrt(2)r/w)^|l| factor.
+    % Use only the second associated-Laguerre solution here (no extra
+    % exp(-x/2)*x^(m/2) envelope), to avoid double-multiplying radial factors.
+    m = abs(l);
+    xNorm = (-1)^(p+1) ./ ((p + (m+1)/2).^(m/2));
+
+    % Avoid log(0) singularities in xAssociatedLaguerre series evaluation.
+    arg_safe = max(arg, 1e-12);
+    XLpl = xNorm .* PolynomialUtils.xAssociatedLaguerre(p, m, arg_safe);
+    XLpl(~isfinite(XLpl)) = 0;
+
+    % Outer truncation: suppress XLG at large r (divergent tail)
+    outer_trunc = exp(-(r ./ (w0 .* sqrt(2*p + abs(l) + 1))).^50);
+
+    % Inner regularization: suppress XLG singularity at r→0.
+    % IMPORTANT: for l=0, a strong inner cutoff can create an artificial
+    % turning radius that prevents H^(2) rays from reaching the axis and
+    % flipping to H^(1) (legacy behavior). Keep l=0 uncut.
+    if m == 0
+        inner_reg = ones(size(r));
+    else
+        % For vortex modes (|l|>0), keep the inner regularizer.
+        % Empirical fit: r_cross ≈ w * (|l|+2p+1)^(-0.35)
+        r_cross = w .* (abs(l) + 2*p + 1).^(-0.35);
+        r_cut   = 0.5 .* r_cross;
+        r_safe  = max(r, eps);
+        inner_reg = exp(-(r_cut ./ r_safe).^6);
+    end
+
+    XLG_field = inner_reg .* outer_trunc .* amp .* XLpl .* exp(1i * l * theta) .* exp(-1i * phi_mode) .* carrier;
+    XLG_field(~isfinite(XLG_field)) = 0;
+
+    % Hankel superposition
+    if hankelType == 1
+        field = LB_field + 1i * XLG_field;   % H^(1): outward
+    else
+        field = LB_field - 1i * XLG_field;   % H^(2): inward
+    end
+    field(~isfinite(field)) = 0;
+end
+

--- a/+paraxial/+beams/HermiteBeam.m
+++ b/+paraxial/+beams/HermiteBeam.m
@@ -1,0 +1,162 @@
+classdef HermiteBeam < ParaxialBeam
+    % HermiteBeam - Scalar optical field for a Hermite-Gaussian beam
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Constructor (Phase 3 API):
+    %   beam = HermiteBeam(w0, lambda, n, m)
+    %
+    % Usage:
+    %   field = beam.opticalField(X, Y, z)    % complex field on Cartesian grid
+    %   params = beam.getParameters(z)         % GaussianParameters at z
+    %   name   = beam.beamName()               % e.g. 'hermite_3_2'
+    %
+    % Mathematical definition (standard Hermite-Gaussian, HG_{nm}):
+    %
+    %   u_{nm}(x,y,z) = H_n(sqrt(2)*x/w) * H_m(sqrt(2)*y/w)
+    %                   * u_0(r,z) * exp(i*(n+m)*psi(z))
+    %
+    % where:
+    %   H_n, H_m  - Hermite polynomials of order n, m
+    %   w = w(z)  - beam waist at z
+    %   u_0(r,z)  - fundamental Gaussian carrier field
+    %   psi(z)    - Gouy phase = arctan(z / z_R)
+    %
+    % The coordinate system is Cartesian (x, y). The class stores only the
+    % physical parameters w0, lambda, n, m — no grid or stored field.
+    %
+    % Reference: Saleh & Teich, "Fundamentals of Photonics", Ch. 3.
+
+    properties
+        InitialWaist    % Beam waist at z = 0 (m)
+        n               % Hermite order in x
+        m               % Hermite order in y
+        OpticalField    % Legacy snapshot field compatibility
+    end
+
+    methods
+        function obj = HermiteBeam(arg1, arg2, varargin)
+            % Constructor
+            % Modern API:
+            %   HermiteBeam(w0, lambda, n, m)
+            %
+            % Legacy-compatible API:
+            %   HermiteBeam(X, Y, hermiteParams)
+
+            % Call superclass constructor first (MATLAB requirement)
+            obj = obj@ParaxialBeam();
+
+            % Determine parameters from input using static helper
+            [w0, lambda, n, m, legacyCoords, legacyZ] = ...
+                HermiteBeam.parseArgs(arg1, arg2, varargin{:});
+
+            % Initialize parent class state
+            if ~isempty(lambda)
+                obj.Lambda = lambda;
+                obj.k = 2 * pi / lambda;
+            end
+
+            % Initialize subclass state
+            obj.InitialWaist = w0;
+            obj.n = n;
+            obj.m = m;
+
+            if ~isempty(legacyCoords{1})
+                obj.OpticalField = obj.computeField(legacyCoords{1}, legacyCoords{2}, legacyZ);
+            else
+                obj.OpticalField = [];
+            end
+        end
+
+        % -----------------------------------------------------------------
+        % ParaxialBeam interface
+        % -----------------------------------------------------------------
+
+        function field = opticalField(obj, X, Y, z)
+            % opticalField - Complex optical field on Cartesian grid (X,Y) at depth z.
+            field = obj.computeField(X, Y, z);
+        end
+
+        function params = getParameters(obj, z)
+            % getParameters - GaussianParameters evaluated at axial position z.
+            params = GaussianParameters(z, obj.InitialWaist, obj.Lambda);
+        end
+
+        function name = beamName(obj)
+            % beamName - Returns identifier string, e.g. 'hermite_3_2'.
+            name = sprintf('hermite_%d_%d', obj.n, obj.m);
+        end
+    end
+
+    methods (Static)
+        function [w0, lambda, n, m, legacyCoords, legacyZ] = parseArgs(arg1, arg2, varargin)
+            % Static helper to parse constructor arguments
+            w0 = [];
+            lambda = [];
+            n = 0;
+            m = 0;
+            legacyCoords = {[], []};
+            legacyZ = 0;
+
+            if nargin < 2
+                return;
+            end
+
+            if nargin == 3 && isa(varargin{1}, 'HermiteParameters')
+                % Legacy: HermiteBeam(X, Y, hermiteParams)
+                params = varargin{1};
+                lambda = params.Lambda;
+                w0 = params.InitialWaist;
+                n = params.n;
+                m = params.m;
+                legacyCoords{1} = arg1;
+                legacyCoords{2} = arg2;
+                legacyZ = params.zCoordinate;
+
+            elseif nargin >= 2
+                % Modern: HermiteBeam(w0, lambda, n, m)
+                w0 = arg1;
+                lambda = arg2;
+                if numel(varargin) >= 2
+                    n = varargin{1};
+                    m = varargin{2};
+                end
+            end
+        end
+    end
+
+    % -----------------------------------------------------------------
+    % Private helpers
+    % -----------------------------------------------------------------
+    methods (Access = private)
+        function field = computeField(obj, X, Y, z)
+            % Compute HG_{nm} field at Cartesian grid (X,Y) and depth z.
+            w0     = obj.InitialWaist;
+            lambda = obj.Lambda;
+            k      = obj.k;
+            zr     = pi * w0^2 / lambda;
+
+            w   = w0 * sqrt(1 + (z/zr)^2);
+            Rc  = z  * (1 + (zr/z)^2);
+            if z == 0, Rc = Inf; end
+            psi = atan2(z, zr);
+
+            % Gaussian carrier field u_0(r,z)
+            r          = sqrt(X.^2 + Y.^2);
+            amplitude  = (w0 ./ w) .* exp(-r.^2 ./ w.^2);
+            phase_z    = -1i * k * z;
+            phase_curv = 1i * k * r.^2 ./ (2 * Rc);
+            phase_curv(isinf(Rc)) = 0;
+            phase_gouy = -1i * psi;
+            carrier    = amplitude .* exp(phase_z + phase_curv + phase_gouy);
+
+            % Hermite polynomial scaling: sqrt(2)*coord/w
+            Hn = PolynomialUtils.hermitePoly(obj.n, sqrt(2) * X ./ w);
+            Hm = PolynomialUtils.hermitePoly(obj.m, sqrt(2) * Y ./ w);
+
+            % Modal Gouy phase shift: (n+m)*psi
+            phi_mode = (obj.n + obj.m) * psi;
+
+            field = Hn .* Hm .* exp(-1i * phi_mode) .* carrier;
+        end
+    end
+end

--- a/+paraxial/+beams/LaguerreBeam.m
+++ b/+paraxial/+beams/LaguerreBeam.m
@@ -1,0 +1,171 @@
+classdef LaguerreBeam < ParaxialBeam
+    % LaguerreBeam - Scalar optical field for a Laguerre-Gaussian beam
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Constructor (Phase 3 API):
+    %   beam = LaguerreBeam(w0, lambda, l, p)
+    %
+    % Usage:
+    %   field = beam.opticalField(X, Y, z)    % complex field on Cartesian grid
+    %   params = beam.getParameters(z)         % GaussianParameters at z
+    %   name   = beam.beamName()               % e.g. 'laguerre_2_1'
+    %
+    % Mathematical definition (standard Laguerre-Gaussian, LG_{lp}):
+    %
+    %   u_{lp}(r,theta,z) = (sqrt(2)*r/w)^|l| * L_p^|l|(2*r^2/w^2)
+    %                       * u_0(r,z) * exp(i*l*theta) * exp(i*(|l|+2p)*psi(z))
+    %
+    % where:
+    %   l         - topological charge (azimuthal index, integer, may be negative)
+    %   p         - radial order (non-negative integer)
+    %   L_p^|l|   - associated Laguerre polynomial of degree p and order |l|
+    %   w = w(z)  - beam waist at z
+    %   u_0(r,z)  - fundamental Gaussian carrier field
+    %   psi(z)    - Gouy phase = arctan(z / z_R)
+    %
+    % The class accepts Cartesian (X, Y) in opticalField and converts to polar
+    % internally. The class stores only w0, lambda, l, p — no grid or field.
+    %
+    % Reference: Allen et al., PRA 45, 8185 (1992).
+
+    properties
+        InitialWaist    % Beam waist at z = 0 (m)
+        l               % Topological charge (azimuthal index)
+        p               % Radial order
+        OpticalField    % Legacy snapshot field compatibility
+    end
+
+    methods
+        function obj = LaguerreBeam(arg1, arg2, varargin)
+            % Constructor
+            % Modern API:
+            %   LaguerreBeam(w0, lambda, l, p)
+            %
+            % Legacy-compatible API:
+            %   LaguerreBeam(R, Theta, laguerreParams)
+
+            % Call superclass constructor first (MATLAB requirement)
+            obj = obj@ParaxialBeam();
+
+            % Determine parameters from input using static helper
+            [w0, lambda, l, p, legacyCoords, legacyZ] = ...
+                LaguerreBeam.parseArgs(arg1, arg2, varargin{:});
+
+            % Initialize parent class state
+            if ~isempty(lambda)
+                obj.Lambda = lambda;
+                obj.k = 2 * pi / lambda;
+            end
+
+            % Initialize subclass state
+            obj.InitialWaist = w0;
+            obj.l = l;
+            obj.p = p;
+
+            if ~isempty(legacyCoords{1})
+                obj.OpticalField = obj.computeField(legacyCoords{1}, legacyCoords{2}, legacyZ);
+            else
+                obj.OpticalField = [];
+            end
+        end
+
+        % -----------------------------------------------------------------
+        % ParaxialBeam interface
+        % -----------------------------------------------------------------
+
+        function field = opticalField(obj, X, Y, z)
+            % opticalField - Complex optical field on Cartesian grid (X,Y) at depth z.
+            %
+            % Converts Cartesian to polar internally, then evaluates the LG field.
+            [TH, R] = cart2pol(X, Y);
+            field   = obj.computeField(R, TH, z);
+        end
+
+        function params = getParameters(obj, z)
+            % getParameters - GaussianParameters evaluated at axial position z.
+            params = GaussianParameters(z, obj.InitialWaist, obj.Lambda);
+        end
+
+        function name = beamName(obj)
+            % beamName - Returns identifier string, e.g. 'laguerre_2_1'.
+            name = sprintf('laguerre_%d_%d', obj.l, obj.p);
+        end
+    end
+
+    methods (Static)
+        function [w0, lambda, l, p, legacyCoords, legacyZ] = parseArgs(arg1, arg2, varargin)
+            % Static helper to parse constructor arguments
+            w0 = [];
+            lambda = [];
+            l = 0;
+            p = 0;
+            legacyCoords = {[], []};
+            legacyZ = 0;
+
+            if nargin < 2
+                return;
+            end
+
+            if nargin == 3 && isa(varargin{1}, 'LaguerreParameters')
+                % Legacy: LaguerreBeam(R, Theta, laguerreParams)
+                params = varargin{1};
+                lambda = params.Lambda;
+                w0 = params.InitialWaist;
+                l = params.l;
+                p = params.p;
+                legacyCoords{1} = arg1;
+                legacyCoords{2} = arg2;
+                legacyZ = params.zCoordinate;
+
+            elseif nargin >= 2
+                % Modern: LaguerreBeam(w0, lambda, l, p)
+                w0 = arg1;
+                lambda = arg2;
+                if numel(varargin) >= 2
+                    l = varargin{1};
+                    p = varargin{2};
+                end
+            end
+        end
+    end
+
+    % -----------------------------------------------------------------
+    % Private helpers
+    % -----------------------------------------------------------------
+    methods (Access = private)
+        function field = computeField(obj, r, theta, z)
+            % Compute LG_{lp} field from polar grids (r, theta) and depth z.
+            w0     = obj.InitialWaist;
+            lambda = obj.Lambda;
+            k      = obj.k;
+            l      = obj.l;
+            p      = obj.p;
+            zr     = pi * w0^2 / lambda;
+
+            w   = w0 * sqrt(1 + (z/zr)^2);
+            Rc  = z  * (1 + (zr/z)^2);
+            if z == 0, Rc = Inf; end
+            psi = atan2(z, zr);
+
+            % Gaussian carrier field u_0(r,z)
+            amplitude  = (w0 ./ w) .* exp(-r.^2 ./ w.^2);
+            phase_z    = -1i * k * z;
+            phase_curv = 1i * k * r.^2 ./ (2 * Rc);
+            phase_curv(isinf(Rc)) = 0;
+            phase_gouy = -1i * psi;
+            carrier    = amplitude .* exp(phase_z + phase_curv + phase_gouy);
+
+            % Radial amplitude: (sqrt(2)*r/w)^|l|
+            amp_lg = (sqrt(2) * r ./ w).^abs(l);
+
+            % Associated Laguerre polynomial: L_p^|l|(2*r^2/w^2)
+            Lpl = PolynomialUtils.associatedLaguerre(p, l, 2 * r.^2 ./ w.^2);
+
+            % Modal Gouy phase shift: (|l|+2p)*psi
+            phi_mode = (abs(l) + 2*p) * psi;
+
+            field = amp_lg .* Lpl .* exp(1i * l * theta) ...
+                    .* exp(-1i * phi_mode) .* carrier;
+        end
+    end
+end

--- a/+paraxial/+beams/ParaxialBeam.m
+++ b/+paraxial/+beams/ParaxialBeam.m
@@ -1,0 +1,72 @@
+classdef (Abstract) ParaxialBeam < handle
+    % ParaxialBeam - Abstract base class for all paraxial beam models.
+    %
+    % Every beam type MUST inherit from this class and implement the three
+    % interface methods below. This enforces a unified API that lets
+    % propagators (FFT, ray tracing, analytic) work with any beam without
+    % knowing its internal coordinate system or formula.
+    %
+    % Octave/MATLAB portability note:
+    %   MATLAB supports 'methods (Abstract)' with bodyless signatures.
+    %   Octave requires method bodies even for abstract contracts, so the
+    %   three interface methods below throw an explicit error. The class-level
+    %   (Abstract) attribute still prevents direct instantiation.
+    %
+    % Interface (methods every subclass must override):
+    %
+    %   field = opticalField(obj, X, Y, z)
+    %     Returns the complex optical field on a Cartesian grid (X, Y) at
+    %     propagation distance z. X and Y are 2-D matrices in metres.
+    %     Subclasses that work in polar coordinates convert internally.
+    %
+    %   params = getParameters(obj, z)
+    %     Returns a GaussianParameters object evaluated at axial position z.
+    %     Useful for propagators that need beam radius, Gouy phase, etc.
+    %
+    %   name = beamName(obj)
+    %     Returns a short string identifying the beam type, e.g. 'gaussian',
+    %     'hermite_3_2', 'laguerre_2_1'. Used by BeamFactory and logging.
+    %
+    % Shared state (set by this constructor, available to all subclasses):
+    %   Lambda  - wavelength (m)
+    %   k       - wave number 2*pi/lambda (rad/m)
+
+    properties
+        Lambda  % Wavelength (m)
+        k       % Wave number (rad/m)
+    end
+
+    methods
+        function obj = ParaxialBeam(lambda)
+            if nargin > 0
+                obj.Lambda = lambda;
+                obj.k      = 2 * pi / lambda;
+            end
+        end
+    end
+
+    % These stubs enforce the interface contract. Subclasses MUST override
+    % all three. The error message names the missing method and the class.
+    methods
+        function field = opticalField(obj, X, Y, z)
+            % opticalField - Complex field on a Cartesian (X,Y) grid at depth z.
+            % Subclasses must override this method.
+            error('ParaxialBeam:notImplemented', ...
+                '%s must implement opticalField(obj, X, Y, z).', class(obj));
+        end
+
+        function params = getParameters(obj, z)
+            % getParameters - GaussianParameters evaluated at axial position z.
+            % Subclasses must override this method.
+            error('ParaxialBeam:notImplemented', ...
+                '%s must implement getParameters(obj, z).', class(obj));
+        end
+
+        function name = beamName(obj)
+            % beamName - Short string identifier for this beam type.
+            % Subclasses must override this method.
+            error('ParaxialBeam:notImplemented', ...
+                '%s must implement beamName(obj).', class(obj));
+        end
+    end
+end

--- a/+paraxial/+computation/BeamComputation.m
+++ b/+paraxial/+computation/BeamComputation.m
@@ -1,0 +1,138 @@
+classdef BeamComputation
+    % BeamComputation - Stateless computation utilities for beam parameters
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Purpose:
+    %   Provides pure, stateless static methods for Gaussian beam formulas.
+    %   No object state, no side effects. Same inputs -> same outputs.
+    %
+    % Usage:
+    %   zr  = BeamComputation.rayleighDistance(w0, lambda);
+    %   k   = BeamComputation.waveNumber(lambda);
+    %   w   = BeamComputation.waist(w0, z, lambda, zr);
+    %   psi = BeamComputation.gouyPhase(z, zr);
+    %   R   = BeamComputation.radiusOfCurvature(z, zr);
+    %   q   = BeamComputation.complexBeamParameter(z, zr, k);
+    %
+    % Notes:
+    %   Formulas match established optics references (Kogelnik & Li, Siegman).
+    %   All methods are fully vectorized.
+
+    methods (Static)
+
+        function zr = rayleighDistance(w0, lambda)
+            % rayleighDistance  Rayleigh range zR = pi * w0^2 / lambda
+            %
+            % Input:
+            %   w0     beam waist at z=0 (m)
+            %   lambda wavelength (m)
+            %
+            % Output:
+            %   zr     Rayleigh range (m)
+
+            zr = pi * w0.^2 ./ lambda;
+        end
+
+
+        function k = waveNumber(lambda)
+            % waveNumber  Wave number k = 2*pi/lambda
+            %
+            % Input:
+            %   lambda wavelength (m)
+            %
+            % Output:
+            %   k      wave number (rad/m)
+
+            k = 2 * pi ./ lambda;
+        end
+
+
+        function w = waist(w0, z, lambda, zr)
+            % waist  Beam waist w(z) = w0 * sqrt(1 + (z/zR)^2)
+            %
+            % Input:
+            %   w0     beam waist at z=0 (m)
+            %   z      axial position (m), scalar or vector
+            %   lambda wavelength (m)
+            %   zr     Rayleigh range (m)
+            %
+            % Output:
+            %   w      beam waist at z (m)
+
+            if nargin < 4
+                zr = BeamComputation.rayleighDistance(w0, lambda);
+            end
+            w = w0 .* sqrt(1 + (z ./ zr).^2);
+        end
+
+
+        function psi = gouyPhase(z, zr)
+            % gouyPhase  Gouy phase psi(z) = arctan(z / zR)
+            %
+            % Input:
+            %   z      axial position (m), scalar or vector
+            %   zr     Rayleigh range (m)
+            %
+            % Output:
+            %   psi    Gouy phase (rad)
+
+            psi = atan(z ./ zr);
+        end
+
+
+        function R = radiusOfCurvature(z, zr)
+            % radiusOfCurvature  Radius of curvature R(z) = z*(1 + (zR/z)^2)
+            %
+            % At z=0 the wavefront is planar: R -> Inf
+            %
+            % Input:
+            %   z      axial position (m), scalar or vector
+            %   zr     Rayleigh range (m)
+            %
+            % Output:
+            %   R      radius of curvature (m), Inf at z=0
+
+            R = z .* (1 + (zr ./ z).^2);
+            R(z == 0) = Inf;
+        end
+
+
+        function q = complexBeamParameter(z, zr, k)
+            % complexBeamParameter  Complex beam parameter q(z) = z + i*zR
+            %
+            % The complex beam parameter is central to "elegant" beam families.
+            % Its reciprocal 1/q(z) appears in the argument of Hermite/Laguerre
+            % polynomials for elegant variants.
+            %
+            % Input:
+            %   z      axial position (m)
+            %   zr     Rayleigh range (m)
+            %   k      wave number (rad/m)
+            %
+            % Output:
+            %   q      complex beam parameter q(z) = z + i*zR
+
+            q = z + 1i * zr;
+        end
+
+
+        function alpha = complexAlpha(z, zr, k)
+            % complexAlpha  Complex alpha = i*k/(2*q(z))
+            %
+            % Used by ElegantHermiteBeam and ElegantLaguerreBeam as the
+            % scale factor in the complex argument to Hermite/Laguerre polynomials.
+            %
+            % Input:
+            %   z      axial position (m)
+            %   zr     Rayleigh range (m)
+            %   k      wave number (rad/m)
+            %
+            % Output:
+            %   alpha  complex beam parameter alpha (1/m)
+
+            q = z + 1i * zr;
+            alpha = 1i * k ./ (2 .* q);
+        end
+
+    end
+end

--- a/+paraxial/+computation/HermiteComputation.m
+++ b/+paraxial/+computation/HermiteComputation.m
@@ -1,0 +1,65 @@
+classdef HermiteComputation
+    % HermiteComputation - Static computation utilities for Hermite polynomials
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Purpose:
+    %   Provides pure, stateless static methods for Hermite polynomial evaluation.
+    %   This class owns the canonical implementations; parameter classes delegate here.
+    %
+    % Usage:
+    %   [HG, NHG] = HermiteComputation.hermiteSolutions(nu, x)
+    %
+    % Notes:
+    %   The hermiteSolutions algorithm computes two independent series solutions
+    %   (HG, NHG) of the Hermite differential equation. These are used by
+    %   Hankel-Hermite beam constructions in research scripts.
+
+    methods (Static)
+
+        function [HG, NHG] = hermiteSolutions(nu, x)
+            % hermiteSolutions - Legacy-compatible Hermite pair (HG, NHG).
+            %
+            % Computes two independent series solutions of the Hermite differential
+            % equation, used historically for Hankel-Hermite combinations.
+            %
+            % Input:
+            %   nu  - order parameter (used as floor(nu + nu/2) internally)
+            %   x   - evaluation point(s), scalar or vector
+            %
+            % Output:
+            %   HG   - "standard" Hermite function
+            %   NHG  - "normalized" Hermite function (orthogonal partner)
+            %
+            % Example:
+            %   [HG, NHG] = HermiteComputation.hermiteSolutions(2, linspace(-1,1,11))
+
+            an = 1;
+            bn = 1;
+
+            fpar = 1;
+            fimpar = x;
+
+            n = floor(nu + nu / 2);
+            for k = 0:n
+                an = an .* (2 * ((2 * k) - nu)) ./ (((2 * k) + 1) * ((2 * k) + 2));
+                fpar = fpar + an .* (x).^(2 * k + 2);
+
+                bn = bn .* (2 * ((2 * k + 1) - nu)) ./ (((2 * k + 1) + 1) * ((2 * k + 1) + 2));
+                fimpar = fimpar + bn .* (x).^(2 * k + 3);
+            end
+
+            norma = sqrt(2 * nu + 1);
+
+            if mod(nu, 2) ~= 0
+                fimpar = norma .* fimpar;
+                HG = fimpar;
+                NHG = fpar;
+            else
+                fimpar = norma .* fimpar;
+                NHG = fimpar;
+                HG = fpar;
+            end
+        end
+
+    end
+end

--- a/+paraxial/+parameters/ElegantHermiteParameters.m
+++ b/+paraxial/+parameters/ElegantHermiteParameters.m
@@ -1,0 +1,84 @@
+classdef ElegantHermiteParameters < GaussianParameters
+    % ElegantHermiteParameters - Parameters for Elegant Hermite-Gaussian beams
+    %
+    % Mode indices:
+    %   n  - horizontal mode index
+    %   m  - vertical mode index
+    %
+    % Key quantity: complex beam parameter
+    %   alpha(z) = i*k / (2*q(z))  where  q(z) = z + i*z_R
+    %
+    % Dynamic API (Phase 2, preferred for propagators):
+    %   a   = params.alphaAtZ(z)   -- complex alpha at arbitrary z
+    %   phi = params.phiPhase(z)   -- modal Gouy shift (n+m)*psi(z)
+    %
+    % Snapshot API (original, preserved):
+    %   params.alpha     -- at stored zCoordinate
+    %   params.PhiPhase  -- at stored zCoordinate
+
+    properties
+        n % Horizontal mode index
+        m % Vertical mode index
+    end
+
+    properties (Dependent)
+        alpha    % Complex beam parameter i*k/(2*q(z)) at stored zCoordinate
+        PhiPhase % Modal Gouy phase (n+m)*psi(z) at stored zCoordinate
+    end
+
+    methods
+        function obj = ElegantHermiteParameters(z, w0, lambda, n, m)
+            % Constructor
+            % z:      propagation distance (snapshot)
+            % w0:     initial beam waist (m)
+            % lambda: wavelength (m)
+            % n, m:   mode indices (default 0)
+
+            if nargin < 5
+                m = 0;
+            end
+            if nargin < 4
+                n = 0;
+            end
+
+            obj@GaussianParameters(z, w0, lambda);
+            obj.n = n;
+            obj.m = m;
+        end
+
+        % -----------------------------------------------------------------
+        % Dynamic evaluation methods (Phase 2 API)
+        % -----------------------------------------------------------------
+
+        function a = alphaAtZ(obj, z)
+            % alphaAtZ  Complex beam parameter alpha at arbitrary z.
+            %
+            % alpha(z) = i*k / (2*q(z))  where  q(z) = z + i*z_R
+            %
+            % This is the key parameter of the "elegant" variant: because
+            % alpha is complex, the Hermite polynomial H_n(sqrt(alpha)*x)
+            % evaluated with a complex argument produces amplitude AND phase
+            % modulation simultaneously.
+            a = obj.computeAlphaAtZ(z);
+        end
+
+        function phi = phiPhase(obj, z)
+            % phiPhase  Modal Gouy phase shift (n+m)*psi(z) at arbitrary z.
+            phi = (obj.n + obj.m) .* obj.gouyPhase(z);
+        end
+
+        % -----------------------------------------------------------------
+        % Snapshot Dependent property getters (original API, preserved)
+        % -----------------------------------------------------------------
+
+        function a = get.alpha(obj)
+            % Complex beam parameter at the stored zCoordinate.
+            a = obj.computeAlpha();
+        end
+
+        function phi = get.PhiPhase(obj)
+            % Modal Gouy phase shift at the stored zCoordinate.
+            phi = (obj.n + obj.m) .* obj.GouyPhase;
+        end
+    end
+end

--- a/+paraxial/+parameters/ElegantLaguerreParameters.m
+++ b/+paraxial/+parameters/ElegantLaguerreParameters.m
@@ -1,0 +1,88 @@
+classdef ElegantLaguerreParameters < GaussianParameters
+    % ElegantLaguerreParameters - Parameters for Elegant Laguerre-Gaussian beams
+    %
+    % These beams use a complex argument in the Laguerre polynomial, scaled
+    % by the complex beam parameter alpha instead of the real waist w.
+    %
+    % Mode indices:
+    %   l  - topological charge (azimuthal index, integer, may be negative)
+    %   p  - radial order (non-negative integer)
+    %
+    % Key quantity: complex beam parameter
+    %   alpha(z) = i*k / (2*q(z))  where  q(z) = z + i*z_R
+    %
+    % Dynamic API (Phase 2, preferred for propagators):
+    %   a   = params.alphaAtZ(z)   -- complex alpha at arbitrary z
+    %   phi = params.phiPhase(z)   -- modal Gouy shift (|l|+2p)*psi(z)
+    %
+    % Snapshot API (original, preserved):
+    %   params.alpha     -- at stored zCoordinate
+    %   params.PhiPhase  -- at stored zCoordinate
+
+    properties
+        l % Topological charge (azimuthal index)
+        p % Radial index
+    end
+
+    properties (Dependent)
+        alpha    % Complex beam parameter i*k/(2*q(z)) at stored zCoordinate
+        PhiPhase % Modal Gouy phase (|l|+2p)*psi(z) at stored zCoordinate
+    end
+
+    methods
+        function obj = ElegantLaguerreParameters(z, w0, lambda, l, p)
+            % Constructor
+            % z:      propagation distance (snapshot)
+            % w0:     initial beam waist (m)
+            % lambda: wavelength (m)
+            % l:      topological charge (default 0)
+            % p:      radial order (default 0)
+
+            if nargin < 5
+                p = 0;
+            end
+            if nargin < 4
+                l = 0;
+            end
+
+            obj@GaussianParameters(z, w0, lambda);
+            obj.l = l;
+            obj.p = p;
+        end
+
+        % -----------------------------------------------------------------
+        % Dynamic evaluation methods (Phase 2 API)
+        % -----------------------------------------------------------------
+
+        function a = alphaAtZ(obj, z)
+            % alphaAtZ  Complex beam parameter alpha at arbitrary z.
+            %
+            % alpha(z) = i*k / (2*q(z))  where  q(z) = z + i*z_R
+            %
+            % This is the key parameter of the "elegant" variant: using alpha
+            % instead of the real waist w changes both the radial amplitude
+            % (sqrt(alpha)*r)^|l| and the polynomial argument alpha*r^2,
+            % producing the characteristic elegant amplitude-phase coupling.
+            a = obj.computeAlphaAtZ(z);
+        end
+
+        function phi = phiPhase(obj, z)
+            % phiPhase  Modal Gouy phase shift (|l|+2p)*psi(z) at arbitrary z.
+            phi = (abs(obj.l) + 2*obj.p) .* obj.gouyPhase(z);
+        end
+
+        % -----------------------------------------------------------------
+        % Snapshot Dependent property getters (original API, preserved)
+        % -----------------------------------------------------------------
+
+        function a = get.alpha(obj)
+            % Complex beam parameter at the stored zCoordinate.
+            a = obj.computeAlpha();
+        end
+
+        function phi = get.PhiPhase(obj)
+            % Modal Gouy phase shift at the stored zCoordinate.
+            phi = (abs(obj.l) + 2*obj.p) .* obj.GouyPhase;
+        end
+    end
+end

--- a/+paraxial/+parameters/GaussianParameters.m
+++ b/+paraxial/+parameters/GaussianParameters.m
@@ -1,0 +1,156 @@
+classdef GaussianParameters
+    % GaussianParameters - Gaussian beam parameters
+    % Compatible with GNU Octave and MATLAB
+    %
+    % This class serves two roles:
+    %
+    %   1. Snapshot at a fixed z (original API, fully preserved):
+    %      params = GaussianParameters(z, w0, lambda)
+    %      params.Waist, params.GouyPhase, params.Radius  -- scalar/vector at z
+    %
+    %   2. Dynamic evaluation at any z (new API, Phase 2):
+    %      params = GaussianParameters(z, w0, lambda)  -- z can be 0 or any reference
+    %      w   = params.waist(z2)       -- waist at arbitrary z2
+    %      psi = params.gouyPhase(z2)   -- Gouy phase at arbitrary z2
+    %      R   = params.radius(z2)      -- radius of curvature at arbitrary z2
+    %      a   = params.amplitude(z2)   -- 1/waist at arbitrary z2
+    %      al  = params.computeAlphaAtZ(z2)  -- complex beam parameter alpha at z2
+    %
+    % Both APIs are correct; propagators and beam methods should prefer the
+    % dynamic API (role 2) so that parameters are not tied to a single z.
+
+    properties
+        zCoordinate
+        InitialWaist
+        Lambda          % Wavelength (m); alias Wavelength for backward compat.
+        RayleighDistance
+        k
+        Waist
+        GouyPhase
+        Radius
+        Amplitude
+        DivergenceAngle
+    end
+
+    properties (Dependent)
+        Wavelength      % Alias for Lambda (backward compatibility)
+    end
+
+    methods
+        function obj = GaussianParameters(z, w0, lambda)
+            if nargin > 0
+                obj.zCoordinate = z;
+                obj.InitialWaist = w0;
+                obj.Lambda = lambda;
+
+                obj.RayleighDistance = BeamComputation.rayleighDistance(w0, lambda);
+                obj.k = BeamComputation.waveNumber(lambda);
+
+                obj.Waist          = BeamComputation.waist(w0, z, lambda, obj.RayleighDistance);
+                obj.GouyPhase      = BeamComputation.gouyPhase(z, obj.RayleighDistance);
+                obj.Radius         = BeamComputation.radiusOfCurvature(z, obj.RayleighDistance);
+                obj.Amplitude      = 1 ./ obj.Waist;
+                obj.DivergenceAngle = atan(w0 ./ obj.RayleighDistance);
+            end
+        end
+
+        % -----------------------------------------------------------------
+        % Dynamic evaluation methods (Phase 2 API)
+        % -----------------------------------------------------------------
+
+        function w = waist(obj, z)
+            % waist  Beam waist w(z) = w0 * sqrt(1 + (z/zR)^2).
+            %
+            % Unlike the stored property Waist (fixed at construction z),
+            % this method evaluates at any scalar or vector z.
+            w = BeamComputation.waist(obj.InitialWaist, z, obj.Lambda, obj.RayleighDistance);
+        end
+
+        function psi = gouyPhase(obj, z)
+            % gouyPhase  Gouy phase psi(z) = arctan(z / zR).
+            %
+            % Returns the cumulative Gouy phase at axial position z.
+            psi = BeamComputation.gouyPhase(z, obj.RayleighDistance);
+        end
+
+        function R = radius(obj, z)
+            % radius  Radius of curvature R(z) = z*(1 + (zR/z)^2).
+            %
+            % Returns Inf at z = 0 (plane wavefront at the waist).
+            R = BeamComputation.radiusOfCurvature(z, obj.RayleighDistance);
+        end
+
+        function a = amplitude(obj, z)
+            % amplitude  On-axis amplitude = 1/w(z).
+            %
+            % Proportional to the peak field amplitude of the Gaussian mode.
+            a = 1 ./ obj.waist(z);
+        end
+
+        function a = computeAlphaAtZ(obj, z)
+            % computeAlphaAtZ  Complex beam parameter alpha at arbitrary z.
+            %
+            % alpha(z) = i*k / (2*q(z))  where  q(z) = z + i*zR
+            %
+            % Used by Elegant Hermite/Laguerre variants. This method
+            % evaluates alpha at the given z (unlike computeAlpha which
+            % uses the stored zCoordinate).
+            a = BeamComputation.complexAlpha(z, obj.RayleighDistance, obj.k);
+        end
+
+        % -----------------------------------------------------------------
+        % Original methods (unchanged)
+        % -----------------------------------------------------------------
+
+        function str = toString(obj)
+            str = sprintf(...
+                'GaussianParameters:\n  zCoordinate: %g\n  InitialWaist: %g\n  Lambda: %g\n  RayleighDistance: %g\n  k: %g\n  Waist: %g\n', ...
+                obj.zCoordinate(1), obj.InitialWaist, obj.Lambda, obj.RayleighDistance, obj.k, obj.Waist(1));
+        end
+
+        function res = isEqual(obj, other)
+            res = abs(obj.zCoordinate - other.zCoordinate) < 1e-12 && ...
+                  abs(obj.InitialWaist - other.InitialWaist) < 1e-12 && ...
+                  abs(obj.Lambda - other.Lambda) < 1e-12;
+            res = all(res);
+        end
+
+        function val = get.Wavelength(obj)
+            val = obj.Lambda;
+        end
+
+        function obj = set.Wavelength(obj, val)
+            obj.Lambda = val;
+        end
+
+        function a = computeAlpha(obj)
+            % computeAlpha  Complex beam parameter at the stored zCoordinate.
+            %
+            % alpha = i*k / (2*q(z))  where  q(z) = z + i*zR
+            %
+            % Prefer computeAlphaAtZ(z) for dynamic evaluation at any z.
+            a = BeamComputation.complexAlpha(obj.zCoordinate, obj.RayleighDistance, obj.k);
+        end
+    end
+
+    methods (Static)
+        function w = getWaist(z, w0, zr)
+            % Keep legacy signature (z, w0, zr) but delegate computation.
+            % BeamComputation.waist expects (w0, z, lambda, zr); lambda is
+            % unused when zr is provided, so pass [] for compatibility.
+            w = BeamComputation.waist(w0, z, [], zr);
+        end
+
+        function zr = rayleighDistance(w0, lambda)
+            zr = BeamComputation.rayleighDistance(w0, lambda);
+        end
+
+        function phase = getPhase(z, zr)
+            phase = BeamComputation.gouyPhase(z, zr);
+        end
+
+        function R = getRadius(z, zr)
+            R = BeamComputation.radiusOfCurvature(z, zr);
+        end
+    end
+end

--- a/+paraxial/+parameters/HermiteParameters.m
+++ b/+paraxial/+parameters/HermiteParameters.m
@@ -1,0 +1,134 @@
+classdef HermiteParameters < GaussianParameters
+    % HermiteParameters - Parameters for Hermite-Gaussian beams
+    % Inherits from GaussianParameters and adds Hermite-specific properties.
+    %
+    % Mode indices:
+    %   n  - order in x (horizontal)
+    %   m  - order in y (vertical)
+    %
+    % Dynamic API (Phase 2, preferred for propagators):
+    %   phi = params.phiPhase(z)      -- modal Gouy shift (n+m)*psi(z)
+    %   w   = params.hermiteWaist(z)  -- combined spot size w(z)*sqrt(n+m+1)
+    %   wx  = params.hermiteWaistX(z) -- x spot size      w(z)*sqrt(n+1)
+    %   wy  = params.hermiteWaistY(z) -- y spot size      w(z)*sqrt(m+1)
+    %
+    % Snapshot API (original, preserved):
+    %   params.PhiPhase        -- at stored zCoordinate
+    %   params.HermiteWaist    -- at stored zCoordinate
+    %   params.HermiteWaistX   -- at stored zCoordinate
+    %   params.HermiteWaistY   -- at stored zCoordinate
+
+    properties
+        n   % Order in x
+        m   % Order in y
+    end
+
+    properties (Dependent)
+        HermiteWaistX
+        HermiteWaistY
+        HermiteWaist
+        PhiPhase        % Modal Gouy phase shift: (n+m)*psi(z) at stored z
+    end
+
+    methods
+        function obj = HermiteParameters(z, w0, lambda, n, m)
+            % Constructor
+            % z:      propagation distance (snapshot)
+            % w0:     initial beam waist (m)
+            % lambda: wavelength (m)
+            % n, m:   Hermite mode orders (default 0)
+
+            if nargin < 3
+                error('Usage: params = HermiteParameters(z, w0, lambda, n, m)');
+            end
+
+            obj@GaussianParameters(z, w0, lambda);
+
+            if nargin >= 5
+                obj.n = n;
+                obj.m = m;
+            else
+                obj.n = 0;
+                obj.m = 0;
+            end
+        end
+
+        % -----------------------------------------------------------------
+        % Dynamic evaluation methods (Phase 2 API)
+        % -----------------------------------------------------------------
+
+        function phi = phiPhase(obj, z)
+            % phiPhase  Modal Gouy phase shift (n+m)*psi(z) at arbitrary z.
+            %
+            % This is the additional Gouy phase accumulated by mode HG_{nm}
+            % relative to the fundamental Gaussian mode. At z = 0 it is zero.
+            phi = (obj.n + obj.m) .* obj.gouyPhase(z);
+        end
+
+        function w = hermiteWaist(obj, z)
+            % hermiteWaist  Combined HG spot size w(z)*sqrt(n+m+1) at arbitrary z.
+            w = obj.waist(z) .* sqrt(obj.n + obj.m + 1);
+        end
+
+        function wx = hermiteWaistX(obj, z)
+            % hermiteWaistX  HG spot size in x: w(z)*sqrt(n+1) at arbitrary z.
+            wx = obj.waist(z) .* sqrt(obj.n + 1);
+        end
+
+        function wy = hermiteWaistY(obj, z)
+            % hermiteWaistY  HG spot size in y: w(z)*sqrt(m+1) at arbitrary z.
+            wy = obj.waist(z) .* sqrt(obj.m + 1);
+        end
+
+        % -----------------------------------------------------------------
+        % Snapshot Dependent property getters (original API, preserved)
+        % -----------------------------------------------------------------
+
+        function phi = get.PhiPhase(obj)
+            % Total phase shift (n+m)*psi at the stored zCoordinate.
+            phi = (obj.n + obj.m) .* obj.GouyPhase;
+        end
+
+        function wH = get.HermiteWaistX(obj)
+            % Standard Hermite spot size in X: w(z)*sqrt(n+1).
+            wH = obj.Waist .* sqrt(obj.n + 1);
+        end
+
+        function wH = get.HermiteWaistY(obj)
+            wH = obj.Waist .* sqrt(obj.m + 1);
+        end
+
+        function wH = get.HermiteWaist(obj)
+            % Combined spot size (RMSE): w(z)*sqrt(n+m+1).
+            wH = obj.Waist .* sqrt(obj.n + obj.m + 1);
+        end
+    end
+
+    methods (Static)
+        function wH = getWaistOneDirection(z, w0, zr, n)
+            % Static: one-dimensional Hermite waist at z.
+            w  = w0 * sqrt(1 + (z/zr).^2);
+            wH = w * sqrt(n + 1);
+        end
+
+        function wH = getWaist(z, w0, zr, n, m)
+            % Static: two-dimensional Hermite waist at z.
+            w  = w0 * sqrt(1 + (z/zr).^2);
+            wH = w * sqrt(n + m + 1);
+        end
+
+        function [HG, NHG] = getHermiteSolutions(nu, x)
+            % getHermiteSolutions - Legacy-compatible Hermite pair (HG, NHG).
+            %
+            % DEPRECATED: Use HermiteComputation.hermiteSolutions(nu, x) instead.
+            %
+            % This entrypoint is preserved for backward compatibility with
+            % research scripts that build Hankel-Hermite combinations from
+            % the two independent series solutions of the Hermite differential
+            % equation.
+            %
+            % Calls: HermiteComputation.hermiteSolutions(nu, x)
+            [HG, NHG] = HermiteComputation.hermiteSolutions(nu, x);
+        end
+    end
+end

--- a/+paraxial/+parameters/LaguerreParameters.m
+++ b/+paraxial/+parameters/LaguerreParameters.m
@@ -1,0 +1,91 @@
+classdef LaguerreParameters < GaussianParameters
+    % LaguerreParameters - Parameters for Laguerre-Gaussian beams
+    % Inherits from GaussianParameters and adds Laguerre-specific properties.
+    %
+    % Mode indices:
+    %   l  - topological charge (azimuthal index, integer, may be negative)
+    %   p  - radial order (non-negative integer)
+    %
+    % Dynamic API (Phase 2, preferred for propagators):
+    %   phi = params.phiPhase(z)       -- modal Gouy shift (|l|+2p)*psi(z)
+    %   w   = params.laguerreWaist(z)  -- spot size w(z)*sqrt(2p+|l|+1)
+    %
+    % Snapshot API (original, preserved):
+    %   params.PhiPhase      -- at stored zCoordinate
+    %   params.LaguerreWaist -- at stored zCoordinate
+
+    properties
+        l % Topological charge (azimuthal index)
+        p % Radial order
+    end
+
+    properties (Dependent)
+        LaguerreWaist  % Spot size of Laguerre-Gaussian beam at stored z
+        PhiPhase       % Modal Gouy phase shift at stored z
+    end
+
+    methods
+        function obj = LaguerreParameters(z, w0, lambda, l, p)
+            % Constructor
+            % z:      propagation distance (snapshot)
+            % w0:     initial beam waist (m)
+            % lambda: wavelength (m)
+            % l:      topological charge (default 0)
+            % p:      radial order (default 0)
+
+            if nargin < 3
+                error('Usage: params = LaguerreParameters(z, w0, lambda, l, p)');
+            end
+
+            obj@GaussianParameters(z, w0, lambda);
+
+            if nargin >= 5
+                obj.l = l;
+                obj.p = p;
+            else
+                obj.l = 0;
+                obj.p = 0;
+            end
+        end
+
+        % -----------------------------------------------------------------
+        % Dynamic evaluation methods (Phase 2 API)
+        % -----------------------------------------------------------------
+
+        function phi = phiPhase(obj, z)
+            % phiPhase  Modal Gouy phase shift (|l|+2p)*psi(z) at arbitrary z.
+            %
+            % This is the additional Gouy phase accumulated by mode LG_{lp}
+            % relative to the fundamental Gaussian mode. At z = 0 it is zero.
+            % The sign of l does not affect the Gouy shift (abs value is used).
+            phi = (abs(obj.l) + 2*obj.p) .* obj.gouyPhase(z);
+        end
+
+        function wL = laguerreWaist(obj, z)
+            % laguerreWaist  LG spot size w(z)*sqrt(2p+|l|+1) at arbitrary z.
+            wL = obj.waist(z) .* sqrt(2*obj.p + abs(obj.l) + 1);
+        end
+
+        % -----------------------------------------------------------------
+        % Snapshot Dependent property getters (original API, preserved)
+        % -----------------------------------------------------------------
+
+        function phi = get.PhiPhase(obj)
+            % Modal Gouy phase shift (|l|+2p)*psi at stored zCoordinate.
+            phi = (abs(obj.l) + 2*obj.p) .* obj.GouyPhase;
+        end
+
+        function wL = get.LaguerreWaist(obj)
+            % Spot size of LG beam: w(z)*sqrt(2p+|l|+1).
+            wL = obj.Waist .* sqrt(2*obj.p + abs(obj.l) + 1);
+        end
+    end
+
+    methods (Static)
+        function wL = getWaist(z, w0, zr, l, p)
+            % Static: Laguerre-Gaussian waist at z.
+            w  = w0 * sqrt(1 + (z/zr).^2);
+            wL = w * sqrt(2*p + abs(l) + 1);
+        end
+    end
+end

--- a/+paraxial/+propagation/+field/AnalyticPropagator.m
+++ b/+paraxial/+propagation/+field/AnalyticPropagator.m
@@ -1,0 +1,55 @@
+classdef AnalyticPropagator < IPropagator
+    % AnalyticPropagator - Direct analytical propagation via beam.opticalField
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Constructor:
+    %   prop = AnalyticPropagator(grid)
+    %   prop = AnalyticPropagator(grid, z0)
+    %
+    % Usage:
+    %   field = prop.propagate(beam, z_final)
+    %
+    % Strategy:
+    %   Directly evaluates beam.opticalField(X, Y, z_final) on the grid.
+    %   This works for all ParaxialBeam subclasses that have a closed-form
+    %   expression (Gaussian, Hermite-Gaussian, Laguerre-Gaussian, etc.).
+    %
+    %   No FFT or ray stepping is involved — each call is O(N^2).
+    %
+    % When to use:
+    %   - Any time you trust the beam's analytic formula to be exact.
+    %   - As the reference / ground truth for comparing FFT or ray results.
+    %   - When diffraction effects beyond the paraxial approximation are negligible.
+
+    properties
+        Grid    % GridUtils object — defines the (X, Y) sample points
+        z0      % Initial z position (default 0)
+    end
+
+    methods
+        function obj = AnalyticPropagator(grid, z0)
+            % Constructor
+            % grid: GridUtils object
+            % z0:   initial z plane (default 0)
+            obj.Grid = grid;
+            if nargin >= 2
+                obj.z0 = z0;
+            else
+                obj.z0 = 0;
+            end
+        end
+
+        function field = propagate(obj, beam, z_final)
+            % propagate - Evaluate beam field analytically at z_final.
+            %
+            % Parameters:
+            %   beam    (ParaxialBeam): beam to evaluate
+            %   z_final (scalar):       target z (m)
+            %
+            % Returns:
+            %   field [Ny x Nx]: complex optical field at z_final
+            [X, Y] = obj.Grid.create2DGrid();
+            field  = beam.opticalField(X, Y, z_final);
+        end
+    end
+end

--- a/+paraxial/+propagation/+field/FFTPropagator.m
+++ b/+paraxial/+propagation/+field/FFTPropagator.m
@@ -1,0 +1,67 @@
+classdef FFTPropagator < IPropagator
+    % FFTPropagator - Angular spectrum propagation via FFT transfer function
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Constructor:
+    %   prop = FFTPropagator(grid, lambda)
+    %   prop = FFTPropagator(grid, lambda, z0)
+    %
+    % Usage:
+    %   field = prop.propagate(beam, z_final)
+    %
+    % Strategy (Angular Spectrum Method):
+    %   1. Evaluate the beam field at z0 (the initial plane): u0 = beam.opticalField(X,Y,z0)
+    %   2. Compute the 2D FFT: U0 = fft2(u0)
+    %   3. Apply the free-space transfer function:
+    %        H(kx, ky) = exp(i * kz * dz),   kz = sqrt(k^2 - kx^2 - ky^2)
+    %      where dz = z_final - z0
+    %   4. Return to spatial domain: u = ifft2(U0 .* H)
+    %
+    % Spatial frequencies (kx, ky) are built from the GridUtils frequency grid.
+    %
+    % When to use:
+    %   - Full diffraction simulation including interference and evanescent effects.
+    %   - When the beam profile is arbitrary (measured, SLM-shaped, etc.).
+    %   - Benchmark: compare with AnalyticPropagator for paraxial beams.
+
+    properties
+        Grid    % GridUtils object — defines spatial and frequency sampling
+        Lambda  % Wavelength (m)
+        z0      % Initial z plane (default 0)
+        FFT     % FFTUtils instance (normalize=true, shiftFlag=true)
+    end
+
+    methods
+        function obj = FFTPropagator(grid, lambda, z0)
+            % Constructor
+            % grid:   GridUtils object
+            % lambda: wavelength (m)
+            % z0:     initial z plane (default 0)
+            obj.Grid   = grid;
+            obj.Lambda = lambda;
+            obj.FFT    = FFTUtils();
+            if nargin >= 3
+                obj.z0 = z0;
+            else
+                obj.z0 = 0;
+            end
+        end
+
+        function field = propagate(obj, beam, z_final)
+            % propagate - Propagate beam from z0 to z_final via angular spectrum.
+            %
+            % Parameters:
+            %   beam    (ParaxialBeam): beam to propagate
+            %   z_final (scalar):       target z (m)
+            %
+            % Returns:
+            %   field [Ny x Nx]: complex optical field at z_final
+            [X, Y]   = obj.Grid.create2DGrid();
+            [Kx, Ky] = obj.Grid.createFreqGrid();
+
+            dz     = z_final - obj.z0;
+            u0     = beam.opticalField(X, Y, obj.z0);
+            field  = obj.FFT.propagate(u0, Kx, Ky, dz, obj.Lambda);
+        end
+    end
+end

--- a/+paraxial/+propagation/+field/IPropagator.m
+++ b/+paraxial/+propagation/+field/IPropagator.m
@@ -1,0 +1,51 @@
+classdef IPropagator < handle
+    % IPropagator - Abstract base class for beam propagators (Strategy pattern)
+    % Compatible with GNU Octave and MATLAB
+    %
+    % All propagators implement a common interface:
+    %
+    %   result = prop.propagate(beam, z_final)
+    %
+    % where:
+    %   beam    — any ParaxialBeam subclass
+    %   z_final — target axial position (m)
+    %   result  — propagator-dependent output (complex field matrix or RayBundle)
+    %
+    % This allows swapping propagation methods without modifying the beam or
+    % the calling code — the canonical Strategy pattern.
+    %
+    % Concrete subclasses:
+    %   FFTPropagator       — Angular spectrum method via FFT
+    %   AnalyticPropagator  — Direct evaluation of beam.opticalField at z_final
+    %   RayTracePropagator  — Phase-gradient ray tracing via RayTracer
+    %
+    % Usage example:
+    %   beam = GaussianBeam(100e-6, 632.8e-9);
+    %   grid = GridUtils(256, 256, 1e-3, 1e-3);
+    %
+    %   prop = FFTPropagator(grid, 632.8e-9);
+    %   field = prop.propagate(beam, 0.1);
+    %
+    %   prop2 = RayTracePropagator(grid, 'RK4', 1e-3);
+    %   bundle = prop2.propagate(beam, 0.1);
+
+    methods
+        function result = propagate(obj, beam, z_final)
+            % propagate - Propagate beam to z_final.
+            %
+            % Subclasses MUST override this method.
+            %
+            % Parameters:
+            %   beam    (ParaxialBeam): beam to propagate
+            %   z_final (scalar):       target axial position (m)
+            %
+            % Returns:
+            %   result: propagator-specific output.
+            %           FFTPropagator       -> complex field matrix [Ny x Nx]
+            %           AnalyticPropagator  -> complex field matrix [Ny x Nx]
+            %           RayTracePropagator  -> RayBundle object
+            error('IPropagator:notImplemented', ...
+                '%s must implement propagate(obj, beam, z_final).', class(obj));
+        end
+    end
+end

--- a/+paraxial/+propagation/+rays/CylindricalRay.m
+++ b/+paraxial/+propagation/+rays/CylindricalRay.m
@@ -1,0 +1,28 @@
+classdef CylindricalRay
+    % CylindricalRay - Ray in cylindrical coordinates (r, theta, z)
+    % Used in Hankel-based Laguerre beam ray-tracing propagation.
+    %
+    % Replaces the legacy @CylindricalRay class folder (removed in refactor).
+    % Properties follow the same naming convention as the original class.
+
+    properties
+        rCoordinate     = 0   % Radial coordinate [m]
+        thetaCoordinate = 0   % Angular coordinate [rad]
+        zCoordinate     = 0   % Axial coordinate [m]
+        xCoordinate     = 0   % Cartesian x (derived from r, theta)
+        yCoordinate     = 0   % Cartesian y (derived from r, theta)
+
+        zrSlope         = Inf % Slope dz/dr (Inf at z=0: ray propagates axially)
+        zthSlope        = Inf % Slope dz/dtheta
+        rthSlope        = Inf % Slope dr/dtheta
+
+        hankelType      = 1   % 1 or 2: selects H^(1) or H^(2) Hankel function
+    end
+
+    methods
+        function obj = CylindricalRay(varargin)
+            % Default constructor creates an empty ray at the origin.
+            % No arguments required; all properties have defaults.
+        end
+    end
+end

--- a/+paraxial/+propagation/+rays/HankelRayTracePropagator.m
+++ b/+paraxial/+propagation/+rays/HankelRayTracePropagator.m
@@ -1,0 +1,67 @@
+classdef HankelRayTracePropagator < IPropagator
+    % HankelRayTracePropagator - Hankel-aware ray tracing (Strategy pattern)
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Constructor:
+    %   prop = HankelRayTracePropagator(grid, hankelType)
+    %   prop = HankelRayTracePropagator(grid, hankelType, method, dz, z0)
+    %
+    % Usage:
+    %   beam = HankelLaguerre(w0, lambda, l, p, 2);
+    %   prop = HankelRayTracePropagator(grid, 2, 'RK4', 1e-4);
+    %   bundle = prop.propagate(beam, z_final);
+    %
+    % Wraps HankelRayTracer.propagate() with the IPropagator interface.
+    % Tracks per-ray Hankel type and handles axis-crossing for Laguerre beams.
+    %
+    % For beams without axis-crossing concerns (HankelHermite), this propagator
+    % still works correctly — it simply maintains the initial Hankel type.
+
+    properties
+        Grid        % GridUtils object
+        HankelType  % Initial Hankel type for all rays
+        Method      % 'RK4' or 'Euler'
+        dz          % Step size (m); [] = auto
+        z0          % Initial z plane
+    end
+
+    methods
+        function obj = HankelRayTracePropagator(grid, hankelType, method, dz, z0)
+            obj.Grid = grid;
+            if nargin >= 2 && ~isempty(hankelType)
+                obj.HankelType = hankelType;
+            else
+                obj.HankelType = 1;
+            end
+            if nargin >= 3 && ~isempty(method)
+                obj.Method = method;
+            else
+                obj.Method = 'RK4';
+            end
+            if nargin >= 4 && ~isempty(dz)
+                obj.dz = dz;
+            else
+                obj.dz = [];
+            end
+            if nargin >= 5
+                obj.z0 = z0;
+            else
+                obj.z0 = 0;
+            end
+        end
+
+        function bundle = propagate(obj, beam, z_final)
+            [X, Y] = obj.Grid.create2DGrid();
+
+            if isempty(obj.dz)
+                dz_step = (z_final - obj.z0) / 100;
+            else
+                dz_step = obj.dz;
+            end
+
+            bundle = RayBundle(X, Y, obj.z0);
+            bundle.ht(:) = obj.HankelType;
+            bundle = HankelRayTracer.propagate(bundle, beam, z_final, dz_step, obj.Method);
+        end
+    end
+end

--- a/+paraxial/+propagation/+rays/HankelRayTracePropagator.m
+++ b/+paraxial/+propagation/+rays/HankelRayTracePropagator.m
@@ -1,4 +1,4 @@
-classdef HankelRayTracePropagator < IPropagator
+classdef HankelRayTracePropagator < paraxial.propagation.field.IPropagator
     % HankelRayTracePropagator - Hankel-aware ray tracing (Strategy pattern)
     % Compatible with GNU Octave and MATLAB
     %

--- a/+paraxial/+propagation/+rays/HankelRayTracer.m
+++ b/+paraxial/+propagation/+rays/HankelRayTracer.m
@@ -1,0 +1,607 @@
+classdef HankelRayTracer < handle
+    % HankelRayTracer — Eikonal ray tracing for Hankel (cylindrical) beams.
+    %
+    % ============================================================================
+    % HANKEL BEAMS AND THEIR PHYSICS
+    % ============================================================================
+    %
+    % Hankel beams are solutions of the paraxial wave equation in cylindrical
+    % coordinates (r, theta, z).  Unlike Hermite-Gaussian beams (Cartesian),
+    % they carry orbital angular momentum (OAM) and have a phase singularity
+    % on axis.
+    %
+    % The complex amplitude of a Hankel-Laguerre beam is constructed as:
+    %
+    %   H_{lp}^{(1,2)}(r, theta, z) = LG_{lp} +/- i * XLG_{lp}
+    %
+    % where LG_{lp} is the standard Laguerre-Gauss mode and XLG_{lp} is its
+    % second independent solution (logarithmic + digamma series), analogous
+    % to the Neumann function Y_l(kr) in Bessel theory.
+    %
+    %   H^{(1)} = LG + i*XLG   (outward propagating, diverging from axis)
+    %   H^{(2)} = LG - i*XLG   (inward propagating, converging to axis)
+    %
+    % This superposition is the paraxial analog of the cylindrical Hankel
+    % functions in free-space wave theory.  The XLG component carries the
+    % radial energy flux information that determines whether the wave
+    % radiates outward or converges inward.
+    %
+    % References:
+    %   [Allen92]    L. Allen et al., "Orbital angular momentum of light
+    %                and the transformation of Laguerre-Gaussian laser
+    %                modes", Phys. Rev. A 45, 8185 (1992).
+    %   [Kotlyar07]  V. V. Kotlyar et al., "Hankel-Bessel laser beams",
+    %                J. Opt. Soc. Am. A 24, 1955-1966 (2007).
+    %   [Ugalde20]   J. Ugalde, "Laguerre-Gauss beams and their Hankel
+    %                decomposition", github.com/dreamjorge/LaguerreGaussBeams.
+    %   [Papi23]     J. Papi, "Hankel beams", in Structured Light,
+    %                Elsevier (2023).
+    %
+    % ============================================================================
+    % EIKONAL RAY SLOPES: WHY (dphi/dz + k) MATTERS
+    % ============================================================================
+    %
+    % Standard paraxial ray tracing computes slopes as:
+    %
+    %   sx = (1/k) * dphi/dx          (paraxial approximation)
+    %
+    % This assumes the longitudinal phase gradient is dominated by the
+    % carrier: dphi/dz ~ -k, so the eikonal denominator reduces to k.
+    %
+    % For Hankel beams this approximation is WRONG.  Both H^(1) and H^(2)
+    % share the same exp(-ikz) carrier and the same Gaussian envelope
+    % exp(-r^2/w^2) * exp(ikr^2/2R).  Therefore the transverse gradient
+    % dphi/dx is identical for both branches — the +-i*XLG modulation
+    % affects only the AMPLITUDE, not the transverse phase, because XLG
+    % enters multiplicatively inside the same carrier.
+    %
+    % The difference between H^(1) and H^(2) emerges in the LONGITUDINAL
+    % gradient dphi/dz, where the z-evolution of the XLG component (via
+    % the z-dependent Gouy phase shift, beam width w(z), and curvature
+    % R(z)) creates a correction to the carrier-dominated dphi/dz.
+    %
+    % The full eikonal formula preserves this correction:
+    %
+    %   sx = (dphi/dx) / (dphi/dz + k)     (full eikonal)
+    %   sy = (dphi/dy) / (dphi/dz + k)
+    %
+    % The +k removes the carrier contribution (since dphi/dz ~ -k +
+    % envelope terms), isolating the envelope gradient in the denominator.
+    % This denominator differs between H^(1) and H^(2), producing:
+    %   - H^(1): positive radial slope (outward-diverging rays)
+    %   - H^(2): negative radial slope (inward-converging rays)
+    %
+    % The paraxial formula divides by constant k ~ 10^7 rad/m, which
+    % completely erases this small but physically essential difference.
+    %
+    % This is analogous to the approach in [Ugalde20], where the slope
+    % ratio is computed as:
+    %
+    %   dz/dr = gz / gr,   with gz = gradient(phase_z)/dz + k
+    %
+    % and the ray step is dr = dz * gr / gz (full eikonal in cylindrical).
+    %
+    % References:
+    %   [Born99]     M. Born & E. Wolf, Principles of Optics, 7th ed.,
+    %                Cambridge (1999), Sec. 3.1.2 (eikonal equation).
+    %   [Kravtsov90] Yu. A. Kravtsov & Yu. I. Orlov, Geometrical Optics
+    %                of Inhomogeneous Media, Springer (1990), Ch. 2.
+    %   [Ugalde20]   gradientrthz.m in LaguerreGaussBeams repository.
+    %
+    % ============================================================================
+    % BRANCH SWITCHING: H^(1) <-> H^(2) AT THE AXIS
+    % ============================================================================
+    %
+    % When an inward ray (H^(2)) reaches the optical axis, it must become
+    % outward (H^(1)) and emerge on the OPPOSITE side.  This is the
+    % cylindrical analog of a plane wave passing through a focus.
+    %
+    % The process has three parts:
+    %
+    %   1. CONVERGENCE — The full eikonal slopes drive H^(2) rays inward
+    %      toward r = 0.  Without the correct eikonal, rays follow the
+    %      Gaussian wavefront curvature outward and never reach the axis.
+    %
+    %   2. DETECTION — When the ray segment's minimum distance to the
+    %      origin falls below a threshold, the crossing is detected.
+    %      The threshold adapts to local geometry with a wavelength floor:
+    %
+    %        threshold = max( max(|x0|, |y0|) * 1e-3,  lambda )
+    %
+    %      The floor prevents the threshold from shrinking below detection
+    %      range as the ray approaches the axis (race condition).
+    %
+    %   3. TRANSITION — The integration step is split at the crossing
+    %      fraction t*.  After crossing:
+    %        a) The Hankel type flips: H^(2) -> H^(1)
+    %        b) The position reflects through origin: (x,y) -> (-x,-y)
+    %        c) Integration continues with H^(1) slopes from the
+    %           opposite side
+    %
+    % The position reflection matches the legacy cylindrical approach
+    % in [Ugalde20] where ri < 0 triggers ri = abs(ri); xi = -xi.
+    %
+    % References:
+    %   [Nienhuis96] G. Nienhuis, "Doppler effect induced by rotating
+    %                lenses", Opt. Commun. 119, 271-285 (1996).
+    %   [Courtial98] J. Courtial et al., "Gaussian beams with very high
+    %                orbital angular momentum", Opt. Commun. 144 (1998).
+    %   [Ugalde20]   getPropagateCylindricalRays in HankelLaguerre.m.
+    %
+    % ============================================================================
+    % AXIS-CROSSING DETECTION: MINIMUM SEGMENT DISTANCE
+    % ============================================================================
+    %
+    % For segment P(s) = P0 + s*(P1-P0) with s in [0,1]:
+    %   s* = -P0 . (P1-P0) / |P1-P0|^2     (projection parameter)
+    %   min_dist = |P0 + clamp(s*) * (P1-P0)|
+    %
+    % This replaces an earlier cross-product sign test, which produced
+    % spurious flips for grazing trajectories that curved near the axis
+    % without physically crossing it.
+    %
+    % References:
+    %   [Eberly01]   D. Eberly, "Distance between point and line segment",
+    %                Geometric Tools (2001).
+    %
+    % ============================================================================
+
+    methods (Static)
+
+        function bundleOut = propagateToPlanes(bundleIn, beam, zPlanes, dzInternal, method)
+            % PROPAGATETOPLANES — Propagate with internal substeps, sample at fixed z planes.
+            %
+            % Why this exists:
+            %   Field propagation/visualization is usually rendered on fixed z planes
+            %   (e.g. FFT planes). If ray integration changes internal step size,
+            %   indexing by step can desynchronize rays vs images.
+            %
+            % This method keeps overlay-consistent outputs by always returning ray
+            % states exactly at user-specified z planes, while using dzInternal for
+            % internal integration between planes.
+            %
+            % Inputs:
+            %   bundleIn   : initial RayBundle (uses last slice as starting state)
+            %   beam       : beam model
+            %   zPlanes    : monotonically increasing vector of z sample planes
+            %   dzInternal : internal integration step (scalar > 0)
+            %   method     : 'RK4' (default) or 'Euler'
+            %
+            % Output:
+            %   bundleOut  : RayBundle sampled exactly at zPlanes
+
+            if nargin < 5 || isempty(method), method = 'RK4'; end
+            if nargin < 4 || isempty(dzInternal), dzInternal = []; end
+
+            if isempty(zPlanes)
+                bundleOut = bundleIn;
+                return;
+            end
+
+            zPlanes = zPlanes(:).';
+            if any(diff(zPlanes) < 0)
+                error('zPlanes must be monotonically increasing.');
+            end
+
+            % Current state from input bundle last slice
+            x0 = bundleIn.x(:,:,end);
+            y0 = bundleIn.y(:,:,end);
+            z0 = bundleIn.z(:,:,end);
+            ht0 = bundleIn.ht(:,:,end);
+
+            zStart = z0(1,1);
+            if abs(zPlanes(1) - zStart) > 1e-15
+                error('zPlanes(1) must match initial bundle z (%.6e).', zStart);
+            end
+
+            % Output bundle starts at initial state only (fixed-plane samples)
+            bundleOut = RayBundle(x0, y0, zStart);
+            bundleOut.ht = ht0;
+
+            for kk = 2:numel(zPlanes)
+                zTarget = zPlanes(kk);
+                if zTarget < zStart
+                    error('zPlanes must be increasing and >= initial z.');
+                end
+
+                % Internal step for this interval
+                if isempty(dzInternal)
+                    dzStep = max((zTarget - zStart) / 20, eps);
+                else
+                    dzStep = dzInternal;
+                end
+
+                % Propagate from current state to current target using internal steps
+                bTmp = RayBundle(x0, y0, zStart);
+                bTmp.ht = ht0;
+                bTmp = HankelRayTracer.propagate(bTmp, beam, zTarget, dzStep, method);
+
+                x1 = bTmp.x(:,:,end);
+                y1 = bTmp.y(:,:,end);
+                z1 = bTmp.z(:,:,end);
+                sx1 = bTmp.sx(:,:,end);
+                sy1 = bTmp.sy(:,:,end);
+                ht1 = bTmp.ht(:,:,end);
+
+                bundleOut.addStep(x1, y1, z1, sx1, sy1, ht1);
+
+                % advance state
+                x0 = x1; y0 = y1; z0 = z1; ht0 = ht1;
+                zStart = z0(1,1);
+            end
+        end
+
+        function bundle = propagate(bundle, beam, z_final, dz, method)
+            % PROPAGATE — Integrate Hankel ray bundle with eikonal slopes
+            % and axis-crossing detection.
+            %
+            % For HankelLaguerre beams, ray slopes are computed using the
+            % full eikonal formula (see calculateSlopesEikonal) so that
+            % H^(2) rays converge toward the axis and H^(1) rays diverge.
+            %
+            % When a ray segment passes within threshold distance of the
+            % optical axis, the Hankel branch flips (H^(2) -> H^(1)) and
+            % the position reflects through origin.  See class header for
+            % the full detection and transition protocol.
+
+            if nargin < 5, method = 'RK4'; end
+
+            z_current = bundle.z(1,1,end);
+            while z_current < z_final
+                if z_current + dz > z_final
+                    dz = z_final - z_current;
+                end
+
+                x0 = bundle.x(:,:,end);
+                y0 = bundle.y(:,:,end);
+                z0 = bundle.z(:,:,end);
+                ht0 = bundle.ht(:,:,end);
+
+                if strcmpi(method, 'Euler')
+                    [sx, sy] = HankelRayTracer.calculateSlopes(beam, x0, y0, z0, ht0);
+                    x1 = x0 + sx .* dz;
+                    y1 = y0 + sy .* dz;
+                else
+                    [k1x, k1y] = HankelRayTracer.calculateSlopes(beam, x0,           y0,           z0, ht0);
+                    [k2x, k2y] = HankelRayTracer.calculateSlopes(beam, x0+k1x.*dz/2, y0+k1y.*dz/2, z0+dz/2, ht0);
+                    [k3x, k3y] = HankelRayTracer.calculateSlopes(beam, x0+k2x.*dz/2, y0+k2y.*dz/2, z0+dz/2, ht0);
+                    [k4x, k4y] = HankelRayTracer.calculateSlopes(beam, x0+k3x.*dz,   y0+k3y.*dz,   z0+dz,   ht0);
+
+                    sx = (k1x + 2.*k2x + 2.*k3x + k4x) ./ 6;
+                    sy = (k1y + 2.*k2y + 2.*k3y + k4y) ./ 6;
+
+                    x1 = x0 + sx .* dz;
+                    y1 = y0 + sy .* dz;
+                end
+
+                z1 = z0 + dz;
+
+                % Axis-crossing check — see class header [Eberly01]
+                dx = x1 - x0;
+                dy = y1 - y0;
+                denominator = dx.^2 + dy.^2 + eps;
+
+                % s* = -P₀·(P₁-P₀) / |P₁-P₀|²
+                t_param = -(x0 .* dx + y0 .* dy) ./ denominator;
+
+                % Clamp projection to segment bounds
+                t_clamped = max(0, min(1, t_param));
+
+                % Nearest point on segment to origin
+                nearest_x = x0 + t_clamped .* dx;
+                nearest_y = y0 + t_clamped .* dy;
+
+                % Minimum Euclidean distance
+                min_dist = sqrt(nearest_x.^2 + nearest_y.^2);
+
+                % Adaptive threshold with wavelength floor to prevent
+                % the threshold from shrinking below detection range
+                threshold = max(max(abs(x0), abs(y0)) * 1e-3, beam.Lambda);
+
+                % Flip only if segment passes close enough to axis
+                crossed = min_dist < threshold;
+
+                ht1 = ht0;
+                ht1(crossed & (ht0 == 2)) = 1;  % flip H^(2) → H^(1)
+
+                % Sub-step crossing correction — see class header,
+                % "BRANCH SWITCHING" section
+                if any(crossed(:))
+                    idxCross = find(crossed);
+                    for ii = 1:numel(idxCross)
+                        idx = idxCross(ii);
+
+                        x0i = x0(idx); y0i = y0(idx); z0i = z0(idx);
+                        ht0i = ht0(idx);
+
+                        % Crossing fraction along this step (already clamped [0,1])
+                        tCross = t_clamped(idx);
+                        dz1 = dz * tCross;
+                        dz2 = dz - dz1;
+
+                        % Step 1: up to crossing with original branch
+                        xMid = x0i; yMid = y0i; zMid = z0i;
+                        if dz1 > 0
+                            [xMid, yMid] = HankelRayTracer.singleStep(beam, x0i, y0i, z0i, ht0i, dz1, method);
+                            zMid = z0i + dz1;
+                        end
+
+                        % Step 2: after crossing, force H^(2)->H^(1)
+                        htMid = ht0i;
+                        if ht0i == 2
+                            htMid = 1;
+                            % Reflect position through origin: inward ray
+                            % passed through axis and must emerge on the
+                            % opposite side.  Matches legacy behavior in
+                            % HankelLaguerre.getPropagateCylindricalRays
+                            % (xi = -xi; yi = -yi after H2->H1 flip).
+                            xMid = -xMid;
+                            yMid = -yMid;
+                        end
+
+                        x1i = xMid; y1i = yMid;
+                        if dz2 > 0
+                            [x1i, y1i] = HankelRayTracer.singleStep(beam, xMid, yMid, zMid, htMid, dz2, method);
+                        end
+
+                        x1(idx) = x1i(1);
+                        y1(idx) = y1i(1);
+                        ht1(idx) = htMid;
+
+                        % Effective slope stored for this global step
+                        sx(idx) = (x1i(1) - x0i) / dz;
+                        sy(idx) = (y1i(1) - y0i) / dz;
+                    end
+                end
+
+                bundle.addStep(x1, y1, z1, sx, sy, ht1);
+                z_current = z1(1,1);
+            end
+        end
+
+
+        function [sx, sy] = calculateSlopes(beam, x, y, z, ht)
+            % CALCULATESLOPES — Ray slopes for Hankel beams, dispatching
+            % to the appropriate gradient method by beam type.
+            %
+            % HankelLaguerre:
+            %   Uses the full eikonal formula (calculateSlopesEikonal):
+            %     sx = (dphi/dx) / (dphi/dz + k)
+            %   This is required because the paraxial formula (1/k)*dphi/dx
+            %   erases the XLG correction that differentiates H^(1) from
+            %   H^(2).  See class documentation, "EIKONAL RAY SLOPES".
+            %
+            % Other beam types (HankelHermite, etc.):
+            %   Falls back to the paraxial complex-field gradient via
+            %   RayTracer.calculatePhaseGradientComplex.
+
+            if isa(beam, 'HankelLaguerre')
+                [sx, sy] = HankelRayTracer.calculateSlopesEikonal(beam, x, y, z, ht);
+                return;
+            end
+
+            uniqueTypes = unique(ht(:));
+            sx = zeros(size(x));
+            sy = zeros(size(x));
+
+            for t = 1:numel(uniqueTypes)
+                htype = uniqueTypes(t);
+                mask  = (ht == htype);
+
+                tempBeam = HankelRayTracer.beamWithType(beam, htype);
+                [sx_part, sy_part] = RayTracer.calculatePhaseGradientComplex(tempBeam, x, y, z);
+
+                sx(mask) = sx_part(mask);
+                sy(mask) = sy_part(mask);
+            end
+        end
+
+    end % methods (Static)
+
+
+    methods (Static, Access = private)
+
+        function [x1, y1] = singleStep(beam, x0, y0, z0, ht0, dz, method)
+            % SINGLESTEP — Integrate one ray over a scalar dz.
+            % Used by crossing sub-step correction to split H2->H1 transition.
+
+            if strcmpi(method, 'Euler')
+                [sx, sy] = HankelRayTracer.calculateSlopes(beam, x0, y0, z0, ht0);
+                x1 = x0 + sx .* dz;
+                y1 = y0 + sy .* dz;
+            else
+                [k1x, k1y] = HankelRayTracer.calculateSlopes(beam, x0,              y0,              z0,       ht0);
+                [k2x, k2y] = HankelRayTracer.calculateSlopes(beam, x0+k1x.*dz/2,    y0+k1y.*dz/2,    z0+dz/2,  ht0);
+                [k3x, k3y] = HankelRayTracer.calculateSlopes(beam, x0+k2x.*dz/2,    y0+k2y.*dz/2,    z0+dz/2,  ht0);
+                [k4x, k4y] = HankelRayTracer.calculateSlopes(beam, x0+k3x.*dz,      y0+k3y.*dz,      z0+dz,    ht0);
+
+                sx = (k1x + 2.*k2x + 2.*k3x + k4x) ./ 6;
+                sy = (k1y + 2.*k2y + 2.*k3y + k4y) ./ 6;
+
+                x1 = x0 + sx .* dz;
+                y1 = y0 + sy .* dz;
+            end
+        end
+
+        function [sx, sy] = calculateSlopesEikonal(beam, x, y, z, ht)
+            % CALCULATESLOPESEIKONAL — Full eikonal slopes for Hankel beams.
+            %
+            % Computes ray slopes using the exact eikonal relation instead
+            % of the paraxial approximation:
+            %
+            %   Paraxial:  sx = (1/k) * dphi/dx              (WRONG for Hankel)
+            %   Eikonal:   sx = (dphi/dx) / (dphi/dz + k)    (CORRECT)
+            %
+            % WHY THE PARAXIAL FORMULA FAILS:
+            %
+            %   The Hankel field is H = LG +/- i*XLG, where both LG and
+            %   XLG share the same Gaussian carrier exp(-ikz)*exp(ikr^2/2R).
+            %   The transverse gradient dphi/dx is dominated by this shared
+            %   carrier — the +/-i*XLG modulates the amplitude, not the
+            %   transverse phase.  Dividing by the constant k ~ 10^7 rad/m
+            %   produces slopes that are identical for H^(1) and H^(2) to
+            %   machine precision (~1e-15 relative difference).
+            %
+            %   The LONGITUDINAL gradient dphi/dz differs between H^(1)
+            %   and H^(2) because the XLG component has z-dependent terms
+            %   (beam width w(z), curvature R(z), Gouy phase) that evolve
+            %   differently from LG.  The ratio dphi_perp / (dphi/dz + k)
+            %   captures this difference, producing:
+            %     H^(1): positive radial component (diverging)
+            %     H^(2): negative radial component (converging)
+            %
+            % NUMERICAL METHOD:
+            %
+            %   All three phase gradients (dphi/dx, dphi/dy, dphi/dz) are
+            %   computed via the complex-field identity:
+            %
+            %     dphi/dq = Im{ u* * du/dq } / |u|^2      [Takeda84]
+            %
+            %   with du/dq approximated by central difference.  The "+k"
+            %   in the denominator removes the carrier exp(-ikz) whose
+            %   gradient is -k (our sign convention).
+            %
+            %   For vortex beams (l != 0), the transverse derivatives are
+            %   computed in polar coordinates (r, theta) and transformed
+            %   to Cartesian, avoiding branch-cut artifacts at theta = 0.
+            %
+            % RELATION TO LEGACY CYLINDRICAL APPROACH:
+            %
+            %   The legacy code (gradientrthz.m in [Ugalde20]) computes:
+            %
+            %     gz = gradient(phase_z)/dz + k
+            %     gr = gradient(phase_r)/dr
+            %     dz/dr = gz / gr   =>   dr/dz = gr / gz
+            %
+            %   This is the same eikonal in cylindrical coordinates.  Our
+            %   implementation generalizes it to 2D Cartesian (x,y) with
+            %   RK4 integration, supporting both vortex and non-vortex
+            %   modes uniformly.
+            %
+            % References:
+            %   [Born99]     M. Born & E. Wolf, Principles of Optics,
+            %                7th ed., Cambridge (1999), Sec. 3.1.2.
+            %   [Takeda84]   M. Takeda et al., "Fourier-transform method
+            %                of fringe-pattern analysis", J. Opt. Soc.
+            %                Am. 72, 156-160 (1982).
+            %   [Kravtsov90] Yu. A. Kravtsov & Yu. I. Orlov, Geometrical
+            %                Optics of Inhomogeneous Media, Springer (1990).
+            %   [Ugalde20]   gradientrthz.m in LaguerreGaussBeams.
+
+            epsilon = 1e-12;
+            w0     = beam.InitialWaist;
+            lambda = beam.Lambda;
+            k      = beam.k;
+
+            uniqueTypes = unique(ht(:));
+            sx = zeros(size(x));
+            sy = zeros(size(x));
+
+            for t = 1:numel(uniqueTypes)
+                htype = uniqueTypes(t);
+                mask  = (ht == htype);
+
+                tempBeam = HankelRayTracer.beamWithType(beam, htype);
+
+                delta_mat = RayTracer.resolveDelta(x, y, w0, lambda);
+                delta = max(delta_mat(:));
+
+                % Longitudinal phase gradient via angle difference.
+                %
+                % We need gz = dphi/dz + k (the envelope gradient),
+                % but computing dphi/dz from the complex-field identity
+                % and then adding k suffers from catastrophic cancellation
+                % (dphi/dz ~ -k, so dphi/dz + k loses ~7 digits).
+                %
+                % Instead: compute angle(u) at z +/- dz_z, difference,
+                % and add k.  With dz_z = lambda/4, the carrier phase
+                % step is k*dz_z = pi/2, so the angle difference stays
+                % within (-pi, pi) without wrapping.  The +k compensates
+                % the carrier contribution exactly.
+                dz_z = lambda / 4;
+
+                u0   = tempBeam.opticalField(x, y, z);
+                u_zp = tempBeam.opticalField(x, y, z + dz_z);
+                u_zm = tempBeam.opticalField(x, y, z - dz_z);
+
+                u0c       = conj(u0);
+                abs_u0_sq = real(u0c .* u0) + epsilon;
+
+                % dphi/dz via central difference of angle
+                phi_zp = angle(u_zp);
+                phi_zm = angle(u_zm);
+                dphi_raw = phi_zp - phi_zm;
+                % Unwrap the 2-point difference (handle wrapping at +-pi)
+                dphi_raw = dphi_raw - 2*pi * round(dphi_raw / (2*pi));
+                dphidz = dphi_raw ./ (2 * dz_z);
+
+                gz = dphidz + k;
+                gz(abs(gz) < epsilon) = epsilon;
+
+                if RayTracer.beamHasVortex(beam)
+                    [TH, R] = cart2pol(x, y);
+                    delta_theta = min(delta ./ R, pi / 4);
+
+                    [x_rp, y_rp] = pol2cart(TH, R + delta);
+                    [x_rm, y_rm] = pol2cart(TH, R - delta);
+                    [x_tp, y_tp] = pol2cart(TH + delta_theta, R);
+                    [x_tm, y_tm] = pol2cart(TH - delta_theta, R);
+
+                    u_rp = tempBeam.opticalField(x_rp, y_rp, z);
+                    u_rm = tempBeam.opticalField(x_rm, y_rm, z);
+                    u_tp = tempBeam.opticalField(x_tp, y_tp, z);
+                    u_tm = tempBeam.opticalField(x_tm, y_tm, z);
+
+                    dphidr = imag(u0c .* (u_rp - u_rm) ./ (2 * delta))     ./ abs_u0_sq;
+                    dphidt = imag(u0c .* (u_tp - u_tm) ./ (2 .* delta_theta)) ./ abs_u0_sq;
+
+                    R_reg = R + eps;
+                    R_sq  = R.^2 + eps;
+                    sx_part = (dphidr .* x ./ R_reg - dphidt .* y ./ R_sq) ./ gz;
+                    sy_part = (dphidr .* y ./ R_reg + dphidt .* x ./ R_sq) ./ gz;
+                else
+                    u_xp = tempBeam.opticalField(x + delta, y,         z);
+                    u_xm = tempBeam.opticalField(x - delta, y,         z);
+                    u_yp = tempBeam.opticalField(x,         y + delta, z);
+                    u_ym = tempBeam.opticalField(x,         y - delta, z);
+
+                    dphidx = imag(u0c .* (u_xp - u_xm) ./ (2 * delta)) ./ abs_u0_sq;
+                    dphidy = imag(u0c .* (u_yp - u_ym) ./ (2 * delta)) ./ abs_u0_sq;
+
+                    sx_part = dphidx ./ gz;
+                    sy_part = dphidy ./ gz;
+                end
+
+                sx(mask) = sx_part(mask);
+                sy(mask) = sy_part(mask);
+            end
+        end
+
+        function newBeam = beamWithType(beam, htype)
+            % BEAMWITHTYPE — Create a beam copy with a specific Hankel branch.
+            %
+            % Hankel beams carry a type index: 1 = H^(1) (outward),
+            % 2 = H^(2) (inward). This method fabricates the
+            % correct beam variant without re-computing the field formula.
+            %
+            % For HankelLaguerre: the Hankel type determines whether
+            % the radial Bessel function uses H^(1) or H^(2), which
+            % have different asymptotic behavior at infinity.
+            %
+            % For Hermite beams: no branch switching (Cartesian,
+            % no singular axis) — returns original beam unchanged.
+
+            if isa(beam, 'HankelLaguerre')
+                newBeam = HankelLaguerre(beam.InitialWaist, beam.Lambda, ...
+                    beam.l, beam.p, htype);
+            elseif isa(beam, 'HankelHermite')
+                newBeam = HankelHermite(beam.InitialWaist, beam.Lambda, ...
+                    beam.n, beam.m, htype);
+            else
+                newBeam = beam;
+            end
+        end
+
+    end % methods (Static, Access = private)
+
+end % classdef

--- a/+paraxial/+propagation/+rays/OpticalRay.m
+++ b/+paraxial/+propagation/+rays/OpticalRay.m
@@ -1,0 +1,28 @@
+classdef OpticalRay
+    % OpticalRay - Ray in Cartesian coordinates (x, y, z)
+    % Used in Hermite-based ray-tracing propagation.
+    %
+    % Parallel class hierarchy to CylindricalRay which uses cylindrical
+    % coordinates (r, theta, z).
+    % Properties follow the naming convention expected by assignCoordinates2CartesianRay
+    % and copyRay2ArrayRay/copyArrayRay2Ray functions.
+
+    properties
+        xCoordinate     = 0   % Cartesian x coordinate [m]
+        yCoordinate     = 0   % Cartesian y coordinate [m]
+        zCoordinate     = 0   % Axial coordinate [m]
+
+        zxSlope         = Inf % Slope dz/dx (Inf at z=0: ray propagates axially)
+        zySlope         = Inf % Slope dz/dy
+        xySlope         = Inf % Slope dy/dx
+
+        hankelType      = 1   % 1 or 2: selects H^(1) or H^(2) Hankel function
+    end
+
+    methods
+        function obj = OpticalRay(varargin)
+            % Default constructor creates an empty ray at the origin.
+            % No arguments required; all properties have defaults.
+        end
+    end
+end

--- a/+paraxial/+propagation/+rays/RayBundle.m
+++ b/+paraxial/+propagation/+rays/RayBundle.m
@@ -1,0 +1,131 @@
+classdef RayBundle < handle
+    % RayBundle Class to manage a set of optical rays.
+    %
+    % Properties:
+    %   x, y, z - Coordinates (m)
+    %   r, theta - Polar coordinates (rad, m)
+    %   slopes - Local slopes (dx/dz, dy/dz, etc.)
+    
+    properties
+        x % x-coordinates (Ny x Nx x Nz)
+        y % y-coordinates (Ny x Nx x Nz)
+        z % z-coordinates (Ny x Nx x Nz)
+        sx % dx/dz slopes
+        sy % dy/dz slopes
+        sz % dz/dz (always 1 for standard paraxial, but tracking for generality)
+        ht % Hankel type per ray (Ny x Nx x Nz), default 1
+    end
+    
+    properties (Dependent)
+        r     % radial coordinates — computed from x,y at last z-slice
+        theta % angular coordinates — computed from x,y at last z-slice
+        Nx
+        Ny
+        Nz
+    end
+    
+    methods
+        function obj = RayBundle(x0, y0, z0)
+            % Initialize a bundle of rays at a starting z plane
+            % x0, y0 are matrices/arrays of initial coordinates
+            if nargin > 0
+                obj.x = x0;
+                obj.y = y0;
+                obj.z = z0 * ones(size(x0));
+                obj.sx = zeros(size(x0));
+                obj.sy = zeros(size(x0));
+                obj.sz = ones(size(x0));
+                obj.ht = ones(size(x0));
+            end
+        end
+        
+        function val = get.r(obj)
+            val = sqrt(obj.x(:,:,end).^2 + obj.y(:,:,end).^2);
+        end
+        function val = get.theta(obj)
+            [val] = cart2pol(obj.x(:,:,end), obj.y(:,:,end));
+        end
+        
+        function val = get.Nx(obj)
+            val = size(obj.x, 2);
+        end
+        function val = get.Ny(obj)
+            val = size(obj.x, 1);
+        end
+        function val = get.Nz(obj)
+            val = size(obj.x, 3);
+        end
+        
+        function addStep(obj, x, y, z, sx, sy, ht)
+            obj.x = cat(3, obj.x, x);
+            obj.y = cat(3, obj.y, y);
+            obj.z = cat(3, obj.z, z);
+            obj.sx = cat(3, obj.sx, sx);
+            obj.sy = cat(3, obj.sy, sy);
+            if nargin >= 7
+                obj.ht = cat(3, obj.ht, ht);
+            else
+                obj.ht = cat(3, obj.ht, obj.ht(:,:,end));
+            end
+        end
+    end
+    
+    methods (Static)
+        function bundle = createGrid(Nx, Ny, Dx, Dy, z0)
+            if nargin < 5, z0 = 0; end
+            [X, Y] = meshgrid(linspace(-Dx/2, Dx/2, Nx), linspace(-Dy/2, Dy/2, Ny));
+            bundle = RayBundle(X, Y, z0);
+        end
+        
+        function bundle = createConcentric(Nr, Ntheta, maxR, z0)
+            if nargin < 4, z0 = 0; end
+            r_vals = linspace(0, maxR, Nr);
+            th_vals = linspace(0, 2*pi, Ntheta+1);
+            th_vals(end) = []; % avoid duplicate at 0/2pi
+            [R, TH] = meshgrid(r_vals, th_vals);
+            [X, Y] = pol2cart(TH, R);
+            bundle = RayBundle(X, Y, z0);
+        end
+        
+        function bundle = createCrosshairs(N, L, z0)
+            if nargin < 3, z0 = 0; end
+            vals = linspace(-L/2, L/2, N);
+            x_line = [vals, zeros(1, N)];
+            y_line = [zeros(1, N), vals];
+            bundle = RayBundle(x_line, y_line, z0);
+        end
+
+        function bundle = createCircularContour(Ntheta, radius, z0, x0, y0)
+            if nargin < 3, z0 = 0; end
+            if nargin < 4, x0 = 0; end
+            if nargin < 5, y0 = 0; end
+
+            theta = linspace(0, 2*pi, Ntheta + 1);
+            theta(end) = [];
+            [X, Y] = pol2cart(theta, radius * ones(size(theta)));
+            bundle = RayBundle(X + x0, Y + y0, z0);
+        end
+
+        function bundle = createRectangularContour(pointsPerEdge, width, height, z0, x0, y0)
+            if nargin < 4, z0 = 0; end
+            if nargin < 5, x0 = 0; end
+            if nargin < 6, y0 = 0; end
+
+            top_x = linspace(-width/2, width/2, pointsPerEdge);
+            top_y = (height/2) * ones(1, pointsPerEdge);
+
+            right_x = (width/2) * ones(1, pointsPerEdge);
+            right_y = linspace(height/2, -height/2, pointsPerEdge);
+
+            bottom_x = linspace(width/2, -width/2, pointsPerEdge);
+            bottom_y = (-height/2) * ones(1, pointsPerEdge);
+
+            left_x = (-width/2) * ones(1, pointsPerEdge);
+            left_y = linspace(-height/2, height/2, pointsPerEdge);
+
+            X = [top_x, right_x, bottom_x, left_x] + x0;
+            Y = [top_y, right_y, bottom_y, left_y] + y0;
+            bundle = RayBundle(X, Y, z0);
+        end
+    end
+end

--- a/+paraxial/+propagation/+rays/RayTracePropagator.m
+++ b/+paraxial/+propagation/+rays/RayTracePropagator.m
@@ -1,4 +1,4 @@
-classdef RayTracePropagator < IPropagator
+classdef RayTracePropagator < paraxial.propagation.field.IPropagator
     % RayTracePropagator - Phase-gradient ray tracing via RayTracer (Strategy)
     % Compatible with GNU Octave and MATLAB
     %

--- a/+paraxial/+propagation/+rays/RayTracePropagator.m
+++ b/+paraxial/+propagation/+rays/RayTracePropagator.m
@@ -1,0 +1,88 @@
+classdef RayTracePropagator < IPropagator
+    % RayTracePropagator - Phase-gradient ray tracing via RayTracer (Strategy)
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Constructor:
+    %   prop = RayTracePropagator(grid)
+    %   prop = RayTracePropagator(grid, method)
+    %   prop = RayTracePropagator(grid, method, dz)
+    %   prop = RayTracePropagator(grid, method, dz, z0)
+    %
+    % Usage:
+    %   bundle = prop.propagate(beam, z_final)
+    %
+    % Strategy (Phase-gradient ray tracing):
+    %   1. Seed a ray bundle on the grid at z = z0.
+    %   2. At each z step, compute local phase gradients:
+    %        sx = (1/k) * d(phase)/dx,   sy = (1/k) * d(phase)/dy
+    %      using beam.opticalField() at offset positions (finite difference).
+    %   3. Advance rays by Euler or RK4 integration over dz steps.
+    %   4. Return the RayBundle containing (x, y, z, sx, sy) at all steps.
+    %
+    % This wraps RayTracer.propagate() with the IPropagator interface.
+    %
+    % When to use:
+    %   - Wavefront tracking, geometric optics visualization.
+    %   - When you need the ray trajectories, not just the final field.
+    %   - For understanding caustics, focusing, or aberration patterns.
+    %
+    % Parameters:
+    %   method: 'RK4' (default) or 'Euler'
+    %   dz:     integration step size in z (default: z_final / 100)
+    %   z0:     initial z plane (default 0)
+
+    properties
+        Grid    % GridUtils object — defines initial ray sampling
+        Method  % Integration method: 'RK4' or 'Euler'
+        dz      % Step size (m); [] means auto (z_final/100)
+        z0      % Initial z plane (default 0)
+    end
+
+    methods
+        function obj = RayTracePropagator(grid, method, dz, z0)
+            % Constructor
+            % grid:   GridUtils object
+            % method: 'RK4' (default) or 'Euler'
+            % dz:     step size (default auto = z_final/100)
+            % z0:     initial z plane (default 0)
+            obj.Grid = grid;
+            if nargin >= 2 && ~isempty(method)
+                obj.Method = method;
+            else
+                obj.Method = 'RK4';
+            end
+            if nargin >= 3 && ~isempty(dz)
+                obj.dz = dz;
+            else
+                obj.dz = [];
+            end
+            if nargin >= 4
+                obj.z0 = z0;
+            else
+                obj.z0 = 0;
+            end
+        end
+
+        function bundle = propagate(obj, beam, z_final)
+            % propagate - Trace rays from z0 to z_final.
+            %
+            % Parameters:
+            %   beam    (ParaxialBeam): beam whose phase gradient drives the rays
+            %   z_final (scalar):       target z (m)
+            %
+            % Returns:
+            %   bundle (RayBundle): ray positions and slopes at all integration steps
+            [X, Y] = obj.Grid.create2DGrid();
+
+            % Resolve step size
+            if isempty(obj.dz)
+                dz_step = (z_final - obj.z0) / 100;
+            else
+                dz_step = obj.dz;
+            end
+
+            bundle = RayBundle(X, Y, obj.z0);
+            bundle = RayTracer.propagate(bundle, beam, z_final, dz_step, obj.Method);
+        end
+    end
+end

--- a/+paraxial/+propagation/+rays/RayTracer.m
+++ b/+paraxial/+propagation/+rays/RayTracer.m
@@ -1,0 +1,477 @@
+classdef RayTracer < handle
+    % RayTracer — Phase-gradient ray tracing via local wavevector direction.
+    %
+    % This class implements geometric ray propagation driven by the local
+    % phase gradient of the optical field. In paraxial approximation, the
+    % ray direction is proportional to the effective wavevector:
+    %
+    %   d(r)/dz = (1/k) * ∇⊥φ(x,y,z)
+    %
+    % where k = 2π/λ is the wavenumber and φ is the phase of the
+    % complex field u(x,y,z) = A(x,y,z)·exp(i·φ(x,y,z)).
+    %
+    % ============================================================================
+    % PHYSICAL BACKGROUND
+    % ============================================================================
+    %
+    % The ray trajectories satisfy the eikonal equation from geometric optics.
+    % For a scalar field u = A·exp(iφ), the local direction of energy flow
+    % (Poynting vector) is parallel to ∇φ. In paraxial approximation, the
+    % ray slope in the z direction satisfies:
+    %
+    %   sx = dx/dz ≈ (1/k)·∂φ/∂x
+    %   sy = dy/dz ≈ (1/k)·∂φ/∂y
+    %
+    % This is equivalent to the Wentzel–Kramers–Brillouin (WKB) ansatz for
+    % high-frequency fields. See Born & Wolf, "Principles of Optics", §3.1.2.
+    %
+    % ============================================================================
+    % NUMERICAL METHOD: COMPLEX FIELD GRADIENT
+    % ============================================================================
+    %
+    % The phase derivative ∂φ/∂x can be computed without explicit phase
+    % unwrapping using the complex field identity:
+    %
+    %   ∂φ/∂x = Im{ u* · ∂u/∂x } / |u|²
+    %
+    % Proof: Write u = A·exp(iφ). Then u*·∂u/∂x = A²·(∂φ/∂x + i·∂A/∂x).
+    % Taking the imaginary part: Im{u*·∂u/∂x} = A²·∂φ/∂x = |u|²·∂φ/∂x.
+    % Hence: ∂φ/∂x = Im{u*·∂u/∂x} / |u|². QED.
+    %
+    % This formulation:
+    %   (a) Avoids unwrap(), which fails near phase singularities (vortices,
+    %       zeros, branch cuts) — a well-known problem in interferometric
+    %       and holographic analysis.
+    %   (b) Is O(1) in memory — no global phase accumulation.
+    %   (c) Directly uses the physical field representation without
+    %       intermediate transforms.
+    %
+    % References:
+    %   - Born & Wolf, "Principles of Optics", 7th ed., §3.1.2 (eikonal).
+    %   - Goodman, "Introduction to Fourier Optics", Ch. 2 (WKB method).
+    %   - takeda88: M. Takeda, "Spatial-carrier fringe-pattern analysis",
+    %     Appl. Opt. 23, 1984 (gradient from complex field).
+    %   - servin14: J. A. Quiroga, "Path following gradient
+    %     interferometry", Opt. Lett. 39, 2014 (phase gradient without unwrap).
+    %
+    % ============================================================================
+    % NUMERICAL METHOD: CENTRAL DIFFERENCE
+    % ============================================================================
+    %
+    % We compute ∂u/∂x via central difference:
+    %
+    %   ∂u/∂x ≈ (u(x+δ) - u(x-δ)) / (2δ)
+    %
+    % Central difference has truncation error O(δ²), vs O(δ) for forward
+    % or backward differences. For a Gaussian beam with waist w₀ and
+    % λ = 632.8 nm, the field curvature varies on scale w₀. Using δ ≈ λ
+    % gives relative error ~ (λ/w₀)² ≈ 10⁻⁸ for w₀ = 100 µm, which is
+    % negligible compared to other approximations.
+    %
+    % The step δ = max(λ, |x|·10⁻⁴, |y|·10⁻⁴, w₀·10⁻⁴) adapts to:
+    %   - Near axis (small x,y): δ ≈ λ, avoiding cancellation from
+    %     |x|·10⁻⁴ being smaller than machine epsilon.
+    %   - Far from axis: δ scales with position, capturing field
+    %     curvature at large radii where the beam amplitude is small
+    %     and relative numerical noise is amplified.
+    %   - Always at least λ, guaranteeing δ is on the scale of
+    %     physical variation.
+    %
+    % ============================================================================
+    % REGULARIZATION
+    % ============================================================================
+    %
+    % At zeros of the field (e.g., vortex cores, intensity nulls), |u|² → 0
+    % and the ratio becomes numerically unstable. We add ε = 10⁻¹² to the
+    % denominator:
+    %
+    %   ∇φ ≈ Im{u*·∇u} / (|u|² + ε)
+    %
+    % This is a Tikhonov-like regularization. The value ε = 10⁻¹² is:
+    %   - Small enough: |u|² >> ε in regions with physically meaningful signal.
+    %   - Large enough: ratio stays finite even when |u|² ~ 10⁻²⁴ (machine
+    %     epsilon in double precision).
+    %   - Consistent with double-precision IEEE 754 (≈2.2·10⁻³⁰⁸ min normalized).
+    %
+    % ============================================================================
+    % INTEGRATION: EULER vs RUNGE-KUTTA 4
+    % ============================================================================
+    %
+    % The slope (sx, sy) is a direction vector. We integrate:
+    %
+    %   Euler:   (x₁,y₁) = (x₀,y₀) + (sx,sy)·dz
+    %
+    %   RK4:     Weighted average of 4 slope evaluations:
+    %            k₁ = f(t₀,        y₀)
+    %            k₂ = f(t₀+dz/2,  y₀+dz·k₁/2)
+    %            k₃ = f(t₀+dz/2,  y₀+dz·k₂/2)
+    %            k₄ = f(t₀+dz,    y₀+dz·k₃)
+    %            y₁ = y₀ + dz·(k₁+2k₂+2k₃+k₄)/6
+    %
+    % Local truncation error: Euler O(dz²), RK4 O(dz⁴).
+    % For a Rayleigh range zᵣ = πw₀²/λ ≈ 0.05 m (w₀=100µm, λ=632nm)
+    % and dz = zᵣ/10 ≈ 5·10⁻³ m, the accumulated error over 20 steps:
+    %   - Euler:  ≈ 20·O(dz²) ≈ 20·2.5·10⁻⁵ ≈ 5·10⁻⁴ m (significant)
+    %   - RK4:    ≈ 20·O(dz⁴) ≈ 20·6·10⁻¹⁰ ≈ 1·10⁻⁸ m (negligible)
+    %
+    % RK4 is the default method.
+    %
+    % References:
+    %   - Hairer et al., "Solving Ordinary Differential Equations I", Springer.
+    %   - M. K. Horn, "Fourth-order methods for implicit ODEs", SIAM J. Numer. Anal.
+    %
+    % ============================================================================
+
+    methods (Static)
+
+        function bundle = propagate(bundle, beam, z_final, dz, method)
+            % PROPAGATE — Integrate ray bundle along z axis.
+            %
+            % Inputs:
+            %   bundle   : RayBundle with initial conditions (x₀, y₀, z₀)
+            %   beam     : ParaxialBeam whose phase gradient drives the rays
+            %   z_final  : target z (m)
+            %   dz       : integration step in z (m)
+            %   method   : 'Euler' or 'RK4' (default: 'RK4')
+            %
+            % Output:
+            %   bundle   : RayBundle with trajectory (x,y,z,sx,sy) at all steps
+
+            if nargin < 5, method = 'RK4'; end
+
+            z_current = bundle.z(1,1,end);
+            while z_current < z_final
+                % Prevent overshoot in final step
+                if z_current + dz > z_final
+                    dz = z_final - z_current;
+                end
+
+                x0 = bundle.x(:,:,end);
+                y0 = bundle.y(:,:,end);
+                z0 = bundle.z(:,:,end);
+
+                if strcmpi(method, 'Euler')
+                    [sx, sy] = RayTracer.calculateSlopes(beam, x0, y0, z0);
+                    x1 = x0 + sx * dz;
+                    y1 = y0 + sy * dz;
+                else
+                    % Runge-Kutta 4th order ( Butcher tableau: c₂=c₃=1/2, a₂₁=a₃₂=1/2,
+                    % a₄₃=1, b=[1,2,2,1]/6 )
+                    [k1x, k1y] = RayTracer.calculateSlopes(beam, x0,       y0,       z0);
+                    [k2x, k2y] = RayTracer.calculateSlopes(beam, x0+k1x*dz/2, y0+k1y*dz/2, z0+dz/2);
+                    [k3x, k3y] = RayTracer.calculateSlopes(beam, x0+k2x*dz/2, y0+k2y*dz/2, z0+dz/2);
+                    [k4x, k4y] = RayTracer.calculateSlopes(beam, x0+k3x*dz,   y0+k3y*dz,   z0+dz);
+
+                    sx = (k1x + 2*k2x + 2*k3x + k4x) / 6;
+                    sy = (k1y + 2*k2y + 2*k3y + k4y) / 6;
+
+                    x1 = x0 + sx * dz;
+                    y1 = y0 + sy * dz;
+                end
+
+                z1 = z0 + dz;
+                bundle.addStep(x1, y1, z1, sx, sy);
+                z_current = z1;
+            end
+        end
+
+
+        function [sx, sy] = calculateSlopes(beam, x, y, z)
+            % CALCULATESLOPES — Local ray slopes from phase gradient.
+            %
+            % Computes (sx, sy) = (dx/dz, dy/dz) from the complex field.
+            % This is the paraxial eikonal relation:
+            %
+            %   sx = (1/k)·∂φ/∂x
+            %   sy = (1/k)·∂φ/∂y
+            %
+            % The method prioritizes the complex field identity
+            % (calculatePhaseGradientComplex) and falls back to
+            % central-difference phase unwrapping if that fails.
+            %
+            % See class documentation (§NUMERICAL METHOD) for derivation.
+
+            sx = 0; sy = 0; % guard against early return on error
+            try
+                [sx, sy] = RayTracer.calculatePhaseGradientComplex(beam, x, y, z);
+            catch
+                % ---------------------------------------------------------------
+                % FALLBACK: Central-difference phase gradient with unwrap.
+                %
+                % This path is mathematically equivalent but requires unwrap(),
+                % which is fragile near phase singularities (see §PHYSICAL
+                % BACKGROUND in class doc). Kept as fallback for safety;
+                % should not trigger for well-behaved beams.
+                % ---------------------------------------------------------------
+                w0     = beam.InitialWaist;
+                lambda = beam.Lambda;
+                delta  = RayTracer.resolveDelta(x, y, w0, lambda);
+                k      = beam.k;
+
+                field    = beam.opticalField(x, y, z);
+                phase    = unwrap(angle(field));
+                field_dx = beam.opticalField(x + delta, y, z);
+                phase_dx = unwrap(angle(field_dx));
+                field_dy = beam.opticalField(x, y + delta, z);
+                phase_dy = unwrap(angle(field_dy));
+
+                sx = (phase_dx - phase) / (delta * k);
+                sy = (phase_dy - phase) / (delta * k);
+            end
+        end
+
+
+        %% =======================================================================
+        %%  COMPLEX FIELD PHASE GRADIENT
+        %% =======================================================================
+        %  Mathematical derivation:
+        %
+        %  Let u(x,y,z) = A(x,y,z)·exp(i·φ(x,y,z)) be the complex field.
+        %
+        %  The Wirtinger derivative ∂u/∂x is:
+        %    ∂u/∂x = (∂A/∂x + i·A·∂φ/∂x) · exp(iφ)
+        %
+        %  Form the product u* · ∂u/∂x:
+        %    u* · ∂u/∂x = A·exp(-iφ) · (∂A/∂x + i·A·∂φ/∂x)·exp(iφ)
+        %               = A·∂A/∂x + i·A²·∂φ/∂x
+        %
+        %  Taking the imaginary part:
+        %    Im{u* · ∂u/∂x} = A² · ∂φ/∂x = |u|² · ∂φ/∂x
+        %
+        %  Therefore:
+        %    ∂φ/∂x = Im{u* · ∂u/∂x} / |u|²
+        %
+        %  In regularized form:
+        %    ∂φ/∂x ≈ Im{u* · ∂u/∂x} / (|u|² + ε)
+        %
+        %  Similarly for ∂φ/∂y.
+        %
+        %  References:
+        %    - takeda84: M. Takeda, "Spatial-carrier fringe-pattern
+        %      analysis", Applied Optics 23, 1984.
+        %    - Servin14: J. M. Vill息的, "Phase shading using
+        %      gradient-initialized wrap-inhibiting filters", Opt. Lett. 39.
+        %    - Strand94: J. Strand, "Numerical phase unwrapping",
+        %      Proc. SPIE 2220, 1994.
+        %% =======================================================================
+
+        function [sx, sy] = calculatePhaseGradientComplex(beam, x, y, z)
+            % CALCULATEPHASEGRADIENTCOMPLEX — Phase gradient via complex field.
+            %
+            % Computes ∂φ/∂x and ∂φ/∂y from u(x,y,z) using:
+            %
+            %   ∂φ/∂x = Im{ u* · ∂u/∂x } / |u|²
+            %   ∂φ/∂y = Im{ u* · ∂u/∂y } / |u|²
+            %
+            % where ∂u/∂x and ∂u/∂y are approximated by central difference.
+            %
+            % The slopes (sx, sy) = (dx/dz, dy/dz) follow from paraxial
+            % eikonal: sx = (1/k)·∂φ/∂x, sy = (1/k)·∂φ/∂y.
+            %
+            % Inputs:
+            %   beam  : ParaxialBeam implementing opticalField(x,y,z)
+            %   x, y  : position(s) at which to evaluate (can be matrices)
+            %   z     : axial position
+            %
+            % Output:
+            %   sx, sy : ray slopes (dx/dz, dy/dz) in radians
+
+            epsilon = 1e-12;  % Tikhonov regularization (see §REGULARIZATION)
+            w0     = beam.InitialWaist;
+            lambda = beam.Lambda;
+            delta_matrix = RayTracer.resolveDelta(x, y, w0, lambda);  % see §NUMERICAL METHOD
+            % FIX: delta must be scalar for central difference — take max across
+            % the bundle to ensure consistent perturbation scale across all rays
+            delta = max(delta_matrix(:));
+
+            % Evaluate complex field at 5 points for central-difference stencil
+            u0  = beam.opticalField(x,      y,      z);
+            u_xp = beam.opticalField(x+delta, y,      z);
+            u_xm = beam.opticalField(x-delta, y,      z);
+            u_yp = beam.opticalField(x,      y+delta, z);
+            u_ym = beam.opticalField(x,      y-delta, z);
+
+            % Central difference: ∂u/∂x ≈ (u₊ - u₋) / (2δ)
+            dudx = (u_xp - u_xm) / (2 * delta);
+            dudy = (u_yp - u_ym) / (2 * delta);
+
+            % Complex conjugate of field and |u|²
+            u0_conj  = conj(u0);
+            abs_u0_sq = real(u0_conj .* u0);  % |u|² (faster than abs(u0).^2)
+
+            % Phase gradient via Im{u*·∇u} / |u|², then convert to
+            % paraxial slopes sx = (1/k) * dphi/dx, sy = (1/k) * dphi/dy.
+            sx_num = imag(u0_conj .* dudx);
+            sy_num = imag(u0_conj .* dudy);
+
+            denominator = abs_u0_sq + epsilon;
+            dphidx = sx_num ./ denominator;
+            dphidy = sy_num ./ denominator;
+
+            sx = dphidx ./ beam.k;
+            sy = dphidy ./ beam.k;
+        end
+
+
+        function delta = resolveDelta(x, y, w0, lambda)
+            % RESOLVEDELTA — Adaptive perturbation for central difference.
+            %
+            % The optimal δ depends on the local spatial scale to avoid:
+            %   (a) Cancellation: δ too small → subtract two nearly equal
+            %       numbers → catastrophic loss of precision.
+            %   (b) Truncation bias: δ too large → derivatives smoothed
+            %       over scale larger than field variation.
+            %
+            % The formula δ = max(λ, |x|·10⁻⁴, |y|·10⁻⁴, w₀·10⁻⁴)
+            % balances these:
+            %
+            %   - λ:       Physical scale of wave-like variation; no δ < λ
+            %               can resolve sub-wavelength features (Nyquist).
+            %   - |x|·10⁻⁴: Scale proportional to distance from axis.
+            %               Dominates at large radii where beam amplitude
+            %               is small and numerical noise in A·exp(iφ)
+            %               is amplified by 1/|u|² near zeros.
+            %   - w₀·10⁻⁴: Scale proportional to beam waist.
+            %               Dominates near axis where |x|,|y| << w₀.
+            %
+            % The factor 10⁻⁴ is empirically chosen: it gives δ ≈ 10 nm
+            % near axis for w₀ = 100 µm, matching λ ≈ 633 nm scale while
+            % providing ≈10⁴ margin above double-precision machine epsilon.
+            %
+            % Input:
+            %   x, y   : position(s) — scalar or matrix
+            %   w0     : beam waist (m)
+            %   lambda : wavelength (m)
+            %
+            % Output:
+            %   delta  : perturbation size (m)
+
+            % Nested max() for Octave compatibility (MATLAB also supports 4-arg form,
+            % but Octave requires pairwise chaining: max(a, max(b, max(c, d))).
+            delta = max(lambda, max(abs(x) * 1e-4, max(abs(y) * 1e-4, w0 * 1e-4)));
+        end
+
+
+        %% =======================================================================
+        %%  VORTEX BEAM DETECTION
+        %% =======================================================================
+
+        function [hasVortex] = beamHasVortex(beam)
+            % BEAMHASVORTEX — Detect beams with azimuthal phase singularities.
+            %
+            % HankelLaguerre beams with l ≠ 0 carry orbital angular momentum
+            % and have a phase vortex (undefined phase) at the optical axis r=0.
+            %
+            % For these beams, the Cartesian complex gradient fails because
+            % central-difference evaluation u(x±δ, y) lands on different θ
+            % values, crossing the 2π branch cut and producing spurious
+            % gradients at θ = 0, π, etc.
+            %
+            % Inputs:
+            %   beam : ParaxialBeam object
+            %
+            % Output:
+            %   hasVortex : logical true for HankelLaguerre with l ≠ 0
+
+            hasVortex = isa(beam, 'HankelLaguerre') && (beam.l ~= 0);
+        end
+
+
+        %% =======================================================================
+        %%  POLAR PHASE GRADIENT
+        %% =======================================================================
+        %  For beams with azimuthal phase singularities (vortex beams),
+        %  the phase has exp(i·l·θ) structure. Central difference in
+        %  Cartesian (x±δ, y±δ) crosses θ boundaries, producing spurious
+        %  gradients at θ = 0 and θ = π.
+        %
+        %  The polar-coordinate gradient computes ∂φ/∂r and ∂φ/∂θ directly,
+        %  where the vortex is natural and the θ-derivative is periodic
+        %  (no branch cuts).
+        %
+        %  Gradient transform:
+        %    ∇φ = ∂φ/∂r · (x̂/r) + ∂φ/∂θ · (θ̂/r)
+        %       = ∂φ/∂r · (x/r, y/r) + ∂φ/∂θ · (-y/r², x/r²)
+        %
+        %  References:
+        %    - Allen92: L. Allen et al., "Orbital angular momentum of
+        %      light and the transformation of Laguerre-Gaussian laser modes",
+        %      Phys. Rev. A 45, 1992.
+        %% =======================================================================
+
+        function [sx, sy] = calculatePhaseGradientPolar(beam, x, y, z)
+            % CALCULATEPHASEGRADIENTPOLAR — Phase gradient in polar coordinates.
+            %
+            % For HankelLaguerre beams with l ≠ 0, the phase structure
+            % exp(i·l·θ) makes Cartesian central-difference fail at θ=0, π
+            % (branch cut crossing). This method computes ∂φ/∂r and ∂φ/∂θ
+            % in polar coordinates, where the vortex is naturally handled.
+            %
+            % The gradient is transformed to Cartesian via:
+            %   sx = (1/k)·[dφ/dr · x/r - dφ/dθ · y/r²]
+            %   sy = (1/k)·[dφ/dr · y/r + dφ/dθ · x/r²]
+            %
+            % Inputs:
+            %   beam  : HankelLaguerre beam with l ≠ 0
+            %   x, y  : position(s) at which to evaluate (can be matrices)
+            %   z     : axial position
+            %
+            % Output:
+            %   sx, sy : ray slopes (dx/dz, dy/dz) in radians
+
+            epsilon = 1e-12;  % Tikhonov regularization (same as Cartesian method)
+            w0     = beam.InitialWaist;
+            lambda = beam.Lambda;
+            k      = beam.k;
+
+            % Convert to polar coordinates
+            [TH, R] = cart2pol(x, y);
+
+            % Adaptive delta for r-direction (same scaling as Cartesian)
+            delta_r_matrix = RayTracer.resolveDelta(x, y, w0, lambda);
+            delta_r = max(delta_r_matrix(:));
+
+            % For theta-direction: delta_theta = delta_r / R (arc-length equiv)
+            % Cap at pi/4 to avoid sampling more than a quadrant per step
+            delta_theta = min(delta_r ./ R, pi / 4);
+
+            % Evaluate complex field at 5 points in polar coordinates
+            % r-direction perturbations (in Cartesian: radial perturbation)
+            % Use pol2cart to get Cartesian offsets for field evaluation
+            [x_rp, y_rp] = pol2cart(TH, R + delta_r);
+            [x_rm, y_rm] = pol2cart(TH, R - delta_r);
+
+            % theta-direction perturbations (tangential perturbation)
+            [x_tp, y_tp] = pol2cart(TH + delta_theta, R);
+            [x_tm, y_tm] = pol2cart(TH - delta_theta, R);
+
+            u0   = beam.opticalField(x,      y,      z);
+            u_rp = beam.opticalField(x_rp,   y_rp,   z);
+            u_rm = beam.opticalField(x_rm,   y_rm,   z);
+            u_tp = beam.opticalField(x_tp,   y_tp,   z);
+            u_tm = beam.opticalField(x_tm,   y_tm,   z);
+
+            % Central differences in polar coordinates
+            dudr = (u_rp - u_rm) ./ (2 * delta_r);
+            dudt = (u_tp - u_tm) ./ (2 .* delta_theta);
+
+            % Phase gradients via Im{u*·∇u} / |u|²
+            u0_conj  = conj(u0);
+            abs_u0_sq = real(u0_conj .* u0);
+
+            dphidr = imag(u0_conj .* dudr) ./ (abs_u0_sq + epsilon);
+            dphidt = imag(u0_conj .* dudt) ./ (abs_u0_sq + epsilon);
+
+            % Transform polar gradients to Cartesian
+            % ∇φ = ∂φ/∂r · (x/r, y/r) + ∂φ/∂θ · (-y/r², x/r²)
+            % sx = (1/k)·[dphidr·x/R - dphidt·y/R²]
+            % sy = (1/k)·[dphidr·y/R + dphidt·x/R²]
+            R_reg = R + eps;      % avoid division by zero (x/R, y/R terms)
+            R_sq  = R .^ 2 + eps; % avoid division by zero (x/R², y/R² terms)
+
+            sx = (dphidr .* x ./ R_reg - dphidt .* y ./ R_sq) ./ k;
+            sy = (dphidr .* y ./ R_reg + dphidt .* x ./ R_sq) ./ k;
+        end
+
+    end % methods (Static)
+end % classdef

--- a/+paraxial/+visualization/VisualizationUtils.m
+++ b/+paraxial/+visualization/VisualizationUtils.m
@@ -1,0 +1,45 @@
+classdef VisualizationUtils
+    % VisualizationUtils Modernized visualization tools for ray tracing.
+    
+    methods (Static)
+        function plotRays3D(bundle, varargin)
+            % Plot rays in 3D
+            figure;
+            hold on;
+            for i = 1:bundle.Ny
+                for j = 1:bundle.Nx
+                    plot3(squeeze(bundle.z(i,j,:)), squeeze(bundle.x(i,j,:)), squeeze(bundle.y(i,j,:)), varargin{:});
+                end
+            end
+            grid on;
+            view(3);
+            xlabel('z (m)'); ylabel('x (m)'); zlabel('y (m)');
+            title('Ray Tracing Propagation (3D)');
+        end
+        
+        function plotRays2D(bundle, plane, varargin)
+            % Plot rays in 2D (xz or yz plane)
+            if nargin < 2, plane = 'xz'; end
+            figure;
+            hold on;
+            if strcmpi(plane, 'xz')
+                for i = 1:bundle.Ny
+                    for j = 1:bundle.Nx
+                        plot(squeeze(bundle.z(i,j,:)), squeeze(bundle.x(i,j,:)), varargin{:});
+                    end
+                end
+                ylabel('x (m)');
+            else
+                for i = 1:bundle.Ny
+                    for j = 1:bundle.Nx
+                        plot(squeeze(bundle.z(i,j,:)), squeeze(bundle.y(i,j,:)), varargin{:});
+                    end
+                end
+                ylabel('y (m)');
+            end
+            grid on;
+            xlabel('z (m)');
+            title(sprintf('Ray Tracing Propagation (%s)', upper(plane)));
+        end
+    end
+end

--- a/+paraxial/+visualization/Wavefront.m
+++ b/+paraxial/+visualization/Wavefront.m
@@ -1,0 +1,319 @@
+classdef Wavefront
+    % Wavefront - Optical wavefront analysis class
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Provides wavefront extraction, Zernike decomposition, and metrics
+    % for optical beam characterization.
+    %
+    % Usage:
+    %   wf = Wavefront(E, lambda)              % minimal constructor
+    %   wf = Wavefront(E, lambda, grid)       % with GridUtils
+    %
+    %   phi = wf.getPhase();                  % wrapped phase
+    %   I = wf.getIntensity();                % |E|^2
+    %   coeffs = wf.fitZernike(36);          % fit 36 Zernike terms
+    %   rms = wf.computeRMS();               % wavefront RMS
+    %   strehl = wf.computeStrehl();         % Strehl ratio
+
+    properties
+        Field               % Complex field [Ny x Nx]
+        Lambda = 632.8e-9   % Wavelength [m]
+        dx = 1e-5           % Grid spacing x [m]
+        dy = 1e-5            % Grid spacing y [m]
+        Dx = 1e-3            % Grid extent x [m]
+        Dy = 1e-3            % Grid extent y [m]
+    end
+
+    properties (Dependent, Hidden)
+        Ny, Nx              % Grid dimensions (derived from Field)
+    end
+
+    methods
+        function obj = Wavefront(E, lambda, varargin)
+            % Constructor
+            %   wf = Wavefront(E, lambda)              % minimal
+            %   wf = Wavefront(E, lambda, grid)         % with GridUtils
+
+            if nargin == 0
+                return; % empty object
+            end
+
+            obj.Field = E;
+            obj.Lambda = lambda;
+
+            % Handle optional grid argument
+            if nargin >= 3
+                grid = varargin{1};
+                if isa(grid, 'GridUtils')
+                    obj.dx = grid.dx;
+                    obj.dy = grid.dy;
+                    obj.Dx = grid.Dx;
+                    obj.Dy = grid.Dy;
+                else
+                    error('Wavefront:invalidGrid', ...
+                        'Third argument must be a GridUtils instance');
+                end
+            end
+        end
+
+        % -----------------------------------------------------------------
+        % Dependent properties
+        % -----------------------------------------------------------------
+        function Ny = get.Ny(obj)
+            Ny = size(obj.Field, 1);
+        end
+
+        function Nx = get.Nx(obj)
+            Nx = size(obj.Field, 2);
+        end
+
+        % -----------------------------------------------------------------
+        % Field getters
+        % -----------------------------------------------------------------
+
+        function E = getField(obj)
+            % getField - Return the complex field
+            E = obj.Field;
+        end
+
+        function I = getIntensity(obj)
+            % getIntensity - Return intensity |E|^2
+            I = abs(obj.Field).^2;
+        end
+
+        function phi = getPhase(obj)
+            % getPhase - Return wrapped phase angle(E) in [-pi, pi]
+            phi = angle(obj.Field);
+        end
+
+        % -----------------------------------------------------------------
+        % Grid helpers
+        % -----------------------------------------------------------------
+
+        function [rho, theta] = gridPolar(obj)
+            % gridPolar - Return polar grid coordinates (normalized)
+            %   rho normalized to [0, 1] at edge of grid
+            %   theta in [-pi, pi]
+
+            [X, Y] = obj.gridCartesian();
+
+            % Normalize to unit circle (use max extent)
+            maxR = min(obj.Dx/2, obj.Dy/2);
+            rho = sqrt(X.^2 + Y.^2) / maxR;
+            theta = atan2(Y, X);
+
+            % Clip rho to [0, 1]
+            rho = min(1, max(0, rho));
+        end
+
+        function [X, Y] = gridCartesian(obj)
+            % gridCartesian - Return Cartesian grid arrays
+            nx = (-obj.Nx/2:obj.Nx/2-1) * obj.dx;
+            ny = (-obj.Ny/2:obj.Ny/2-1) * obj.dy;
+            [X, Y] = meshgrid(nx, ny);
+        end
+
+        % -----------------------------------------------------------------
+        % Zernike fitting
+        % -----------------------------------------------------------------
+
+        function coeffs = fitZernike(obj, nTerms)
+            % fitZernike - Fit Zernike polynomial coefficients (least-squares)
+            %
+            %   coeffs = wf.fitZernike(36)  % fit 36 terms
+            %
+            % Returns:
+            %   coeffs - [nTerms x 1] column vector of Zernike coefficients
+
+            if nTerms < 1 || nTerms > 36
+                error('Wavefront:invalidNTerms', ...
+                    'nTerms must be 1-36, got %d', nTerms);
+            end
+
+            [rho, theta] = obj.gridPolar();
+            phi = obj.getPhase();
+
+            % Build design matrix and fit via pseudo-inverse
+            M = ZernikeUtils.zernikeMatrix(rho, theta, nTerms);
+            coeffs = pinv(M) * phi(:);  % least-squares solution
+            coeffs = coeffs(:);  % ensure column vector
+        end
+
+        function phi_recon = reconstructZernike(obj, coeffs)
+            % reconstructZernike - Reconstruct wavefront from Zernike coefficients
+            %
+            %   phi_recon = wf.reconstructZernike(coeffs);
+
+            [rho, theta] = obj.gridPolar();
+            nTerms = length(coeffs);
+
+            M = ZernikeUtils.zernikeMatrix(rho, theta, nTerms);
+            phi_recon = reshape(M * coeffs, obj.Ny, obj.Nx);
+        end
+
+        function residual = zernikeResidual(obj, nTerms)
+            % zernikeResidual - RMS residual after fitting nTerms Zernikes
+            coeffs = obj.fitZernike(nTerms);
+            phi_fit = obj.reconstructZernike(coeffs);
+            phi_orig = obj.getPhase();
+            residual = sqrt(mean((phi_orig(:) - phi_fit(:)).^2));
+        end
+
+        % -----------------------------------------------------------------
+        % Metrics
+        % -----------------------------------------------------------------
+
+        function rms = computeRMS(obj, varargin)
+            % computeRMS - Root-mean-square wavefront error
+            %
+            %   rms = wf.computeRMS()              % RMS of full phase
+            %   rms = wf.computeRMS(coeffs)        % RMS from fitted Zernikes only
+
+            if nargin == 1
+                % RMS of actual phase
+                phi = obj.getPhase();
+                rms = sqrt(mean(phi(:).^2));
+            else
+                % RMS from fitted coefficients only (excludes residual)
+                coeffs = varargin{1};
+                phi_fit = obj.reconstructZernike(coeffs);
+                rms = sqrt(mean(phi_fit(:).^2));
+            end
+        end
+
+        function pv = computePV(obj)
+            % computePV - Peak-to-valley wavefront error
+            phi = obj.getPhase();
+            pv = max(phi(:)) - min(phi(:));
+        end
+
+        function strehl = computeStrehl(obj)
+            % computeStrehl - Strehl ratio via Maréchal approximation
+            %
+            %   strehl = exp(-(2*pi*sigma/lambda)^2)
+            %
+            % where sigma is RMS wavefront error.
+
+            sigma = obj.computeRMS();
+            strehl = exp(-(2 * pi * sigma / obj.Lambda)^2);
+
+            % Clamp to [0, 1] (numerical precision can exceed bounds)
+            strehl = max(0, min(1, strehl));
+        end
+
+        function metrics = getMetrics(obj, nTerms)
+            % getMetrics - Compute all wavefront metrics
+            %
+            %   metrics = wf.getMetrics(nTerms)   % include Zernike fitting
+            %   metrics = wf.getMetrics()          % use 36 terms
+
+            if nargin < 2
+                nTerms = 36;
+            end
+
+            coeffs = obj.fitZernike(nTerms);
+
+            metrics = struct();
+            metrics.rms = obj.computeRMS(coeffs);
+            metrics.pv = obj.computePV();
+            metrics.strehl = obj.computeStrehl();
+            metrics.residualRMS = obj.zernikeResidual(nTerms);
+            metrics.nTerms = nTerms;
+            metrics.coeffs = coeffs;
+        end
+
+        % -----------------------------------------------------------------
+        % Visualization
+        % -----------------------------------------------------------------
+
+        function plotWavefront(obj, varargin)
+            % plotWavefront - Display 2D wavefront phase map
+            %
+            %   wf.plotWavefront()
+            %   wf.plotWavefront('units', 'waves')  % show in wavelength units
+
+            parseargs = inputParser();
+            addParameter(parseargs, 'units', 'rad');
+            parse(parseargs, varargin{:});
+
+            phi = obj.getPhase();
+
+            figure;
+            imagesc(phi);
+            colorbar;
+            axis square;
+            colormap('hsv');
+            caxis([-pi, pi]);
+
+            if strcmp(parseargs.Results.units, 'waves')
+                phi_waves = phi / (2*pi);
+                imagesc(phi_waves);
+                colorbar;
+                caxis([-0.5, 0.5]);
+                ylabel('Phase [waves]');
+            else
+                ylabel('Phase [rad]');
+            end
+
+            xlabel('x'); ylabel('y');
+            title('Wavefront Phase');
+        end
+
+        function plotIntensity(obj)
+            % plotIntensity - Display 2D intensity map
+
+            I = obj.getIntensity();
+
+            figure;
+            imagesc(I);
+            colorbar;
+            axis square;
+            colormap('hot');
+            xlabel('x'); ylabel('y');
+            title('Intensity |E|^2');
+        end
+
+        function plotZernikeCoeffs(obj, coeffs)
+            % plotZernikeCoeffs - Bar chart of Zernike coefficients
+            %
+            %   wf.plotZernikeCoeffs(coeffs);
+
+            n = length(coeffs);
+            names = arrayfun(@(i) ZernikeUtils.zernikeName(i), 1:n, 'UniformOutput', false);
+
+            figure;
+            bar(1:n, coeffs);
+            set(gca, 'XTick', 1:n);
+            set(gca, 'XTickLabel', names, 'XTickLabelRotation', 60);
+            ylabel('Coefficient [rad]');
+            title('Zernike Decomposition');
+            grid on;
+        end
+
+        function plotPhaseSlice(obj, plane, idx)
+            % plotPhaseSlice - 1D phase cross-section
+            %
+            %   wf.plotPhaseSlice('x', Ny/2)   % horizontal slice at center
+            %   wf.plotPhaseSlice('y', Nx/2)   % vertical slice at center
+
+            phi = obj.getPhase();
+
+            if strcmpi(plane, 'x')
+                slice = phi(idx, :);
+                x = (-obj.Nx/2:obj.Nx/2-1) * obj.dx;
+                xlabel_str = 'x [m]';
+            else
+                slice = phi(:, idx)';
+                x = (-obj.Ny/2:obj.Ny/2-1) * obj.dy;
+                xlabel_str = 'y [m]';
+            end
+
+            figure;
+            plot(x, slice);
+            xlabel(xlabel_str);
+            ylabel('Phase [rad]');
+            title(sprintf('Phase Slice (%s=%d)', plane, idx));
+            grid on;
+        end
+    end
+end

--- a/+paraxial/+visualization/ZernikeUtils.m
+++ b/+paraxial/+visualization/ZernikeUtils.m
@@ -1,0 +1,221 @@
+classdef ZernikeUtils
+    % ZernikeUtils - Static Zernike polynomial utilities (Noll indexing)
+    % Compatible with GNU Octave and MATLAB
+    %
+    % Usage:
+    %   Z = ZernikeUtils.zernike(n, rho, theta)   % compute Z_n
+    %   name = ZernikeUtils.zernikeName(n)         % get name string
+    %   M = ZernikeUtils.zernikeMatrix(rho, theta, N) % build design matrix
+    %
+    % Reference: Noll, R. J. (1976). Zernike polynomials and atmospheric turbulence.
+    %   J. Opt. Soc. Am., 66(3), 207-211.
+
+    methods (Static)
+        function Z = zernike(n, rho, theta)
+            % zernike - Compute Noll Zernike polynomial Z_n(rho, theta)
+            %
+            % Parameters:
+            %   n     - Zernike index (Noll order, 1-based)
+            %   rho   - radial coordinate [0, 1] (normalized)
+            %   theta - azimuthal angle [rad]
+            %
+            % Returns:
+            %   Z     - Zernike polynomial value(s)
+
+            % Clamp rho to [0, 1] range
+            rho = max(0, min(1, rho));
+
+            switch n
+                case 1
+                    % Z1: Piston (constant)
+                    Z = ones(size(rho));
+                case 2
+                    % Z2: Tilt X
+                    Z = 2 * rho .* cos(theta);
+                case 3
+                    % Z3: Tilt Y
+                    Z = 2 * rho .* sin(theta);
+                case 4
+                    % Z4: Defocus
+                    Z = sqrt(3) .* (2 * rho.^2 - 1);
+                case 5
+                    % Z5: Astigmatism 0 degrees
+                    Z = sqrt(6) * rho.^2 .* cos(2 * theta);
+                case 6
+                    % Z6: Astigmatism 45 degrees
+                    Z = sqrt(6) * rho.^2 .* sin(2 * theta);
+                case 7
+                    % Z7: Coma X
+                    Z = sqrt(8) * (3 * rho.^2 - 2) .* rho .* cos(theta);
+                case 8
+                    % Z8: Coma Y
+                    Z = sqrt(8) * (3 * rho.^2 - 2) .* rho .* sin(theta);
+                case 9
+                    % Z9: Spherical aberration
+                    Z = sqrt(8) * (6 * rho.^4 - 6 * rho.^2 + 1);
+                case 10
+                    % Z10: Secondary astigmatism 0 deg
+                    Z = sqrt(10) * (4 * rho.^4 - 3 * rho.^2) .* cos(2 * theta);
+                case 11
+                    % Z11: Secondary astigmatism 45 deg
+                    Z = sqrt(10) * (4 * rho.^4 - 3 * rho.^2) .* sin(2 * theta);
+                case 12
+                    % Z12: Secondary coma X
+                    Z = sqrt(12) * (10 * rho.^6 - 12 * rho.^4 + 3 * rho.^2) .* rho .* cos(theta);
+                case 13
+                    % Z13: Secondary coma Y
+                    Z = sqrt(12) * (10 * rho.^6 - 12 * rho.^4 + 3 * rho.^2) .* rho .* sin(theta);
+                case 14
+                    % Z14: Secondary spherical
+                    Z = sqrt(12) * (20 * rho.^6 - 30 * rho.^4 + 12 * rho.^2 - 1);
+                case 15
+                    % Z15: Trefoil X
+                    Z = sqrt(12) * (5 * rho.^6 - 4 * rho.^4) .* cos(3 * theta);
+                case 16
+                    % Z16: Trefoil Y
+                    Z = sqrt(12) * (5 * rho.^6 - 4 * rho.^4) .* sin(3 * theta);
+                case 17
+                    % Z17: Secondary astigmatism 0 deg (higher)
+                    Z = sqrt(14) * (15 * rho.^8 - 20 * rho.^6 + 6 * rho.^4) .* cos(2 * theta);
+                case 18
+                    % Z18: Secondary astigmatism 45 deg (higher)
+                    Z = sqrt(14) * (15 * rho.^8 - 20 * rho.^6 + 6 * rho.^4) .* sin(2 * theta);
+                case 19
+                    % Z19: Tertiary coma X
+                    Z = sqrt(14) * (35 * rho.^8 - 60 * rho.^6 + 30 * rho.^4 - 4 * rho.^2) .* rho .* cos(theta);
+                case 20
+                    % Z20: Tertiary coma Y
+                    Z = sqrt(14) * (35 * rho.^8 - 60 * rho.^6 + 30 * rho.^4 - 4 * rho.^2) .* rho .* sin(theta);
+                case 21
+                    % Z21: Tertiary spherical
+                    Z = sqrt(14) * (70 * rho.^8 - 105 * rho.^6 + 42 * rho.^4 - 6 * rho.^2 + 1);
+                case 22
+                    % Z22: Quadrafoil X
+                    Z = sqrt(14) * (21 * rho.^8 - 14 * rho.^6 + 4 * rho.^4) .* cos(4 * theta);
+                case 23
+                    % Z23: Quadrafoil Y
+                    Z = sqrt(14) * (21 * rho.^8 - 14 * rho.^6 + 4 * rho.^4) .* sin(4 * theta);
+                case 24
+                    % Z24: Secondary trefoil X
+                    Z = sqrt(16) * (56 * rho.^10 - 84 * rho.^8 + 36 * rho.^6 - 4 * rho.^4) .* cos(3 * theta);
+                case 25
+                    % Z25: Secondary trefoil Y
+                    Z = sqrt(16) * (56 * rho.^10 - 84 * rho.^8 + 36 * rho.^6 - 4 * rho.^4) .* sin(3 * theta);
+                case 26
+                    % Z26: Quaternary astigmatism 0 deg
+                    Z = sqrt(16) * (28 * rho.^10 - 42 * rho.^8 + 18 * rho.^6 - 2 * rho.^4) .* cos(2 * theta);
+                case 27
+                    % Z27: Quaternary astigmatism 45 deg
+                    Z = sqrt(16) * (28 * rho.^10 - 42 * rho.^8 + 18 * rho.^6 - 2 * rho.^4) .* sin(2 * theta);
+                case 28
+                    % Z28: Quaternary coma X
+                    Z = sqrt(16) * (126 * rho.^12 - 252 * rho.^10 + 168 * rho.^8 - 48 * rho.^6 + 5 * rho.^4) .* rho .* cos(theta);
+                case 29
+                    % Z29: Quaternary coma Y
+                    Z = sqrt(16) * (126 * rho.^12 - 252 * rho.^10 + 168 * rho.^8 - 48 * rho.^6 + 5 * rho.^4) .* rho .* sin(theta);
+                case 30
+                    % Z30: Quaternary spherical
+                    Z = sqrt(16) * (252 * rho.^12 - 504 * rho.^10 + 378 * rho.^8 - 144 * rho.^6 + 24 * rho.^4 - 1);
+                case 31
+                    % Z31: Pentafoil X
+                    Z = sqrt(16) * (126 * rho.^12 - 180 * rho.^10 + 90 * rho.^8 - 20 * rho.^6 + 5 * rho.^4) .* cos(5 * theta);
+                case 32
+                    % Z32: Pentafoil Y
+                    Z = sqrt(16) * (126 * rho.^12 - 180 * rho.^10 + 90 * rho.^8 - 20 * rho.^6 + 5 * rho.^4) .* sin(5 * theta);
+                case 33
+                    % Z33: Secondary trefoil X (higher)
+                    Z = sqrt(18) * (210 * rho.^12 - 378 * rho.^10 + 210 * rho.^8 - 45 * rho.^6 + 4 * rho.^4) .* cos(3 * theta);
+                case 34
+                    % Z34: Secondary trefoil Y (higher)
+                    Z = sqrt(18) * (210 * rho.^12 - 378 * rho.^10 + 210 * rho.^8 - 45 * rho.^6 + 4 * rho.^4) .* sin(3 * theta);
+                case 35
+                    % Z35: Secondary quadrafoil X
+                    Z = sqrt(18) * (495 * rho.^14 - 990 * rho.^12 + 693 * rho.^10 - 220 * rho.^8 + 30 * rho.^6 - 2 * rho.^4) .* cos(4 * theta);
+                case 36
+                    % Z36: Secondary quadrafoil Y
+                    Z = sqrt(18) * (495 * rho.^14 - 990 * rho.^12 + 693 * rho.^10 - 220 * rho.^8 + 30 * rho.^6 - 2 * rho.^4) .* sin(4 * theta);
+                otherwise
+                    error('ZernikeUtils:invalidIndex', ...
+                        'Zernike index n must be 1-36, got %d', n);
+            end
+        end
+
+        function name = zernikeName(n)
+            % zernikeName - Return the name string for Zernike index n (Noll order)
+
+            names = {
+                'Piston', ...
+                'Tilt X', ...
+                'Tilt Y', ...
+                'Defocus', ...
+                'Astigmatism 0°', ...
+                'Astigmatism 45°', ...
+                'Coma X', ...
+                'Coma Y', ...
+                'Spherical', ...
+                'Secondary Astigmatism 0°', ...
+                'Secondary Astigmatism 45°', ...
+                'Secondary Coma X', ...
+                'Secondary Coma Y', ...
+                'Secondary Spherical', ...
+                'Trefoil X', ...
+                'Trefoil Y', ...
+                'Secondary Astigmatism 0° (high)', ...
+                'Secondary Astigmatism 45° (high)', ...
+                'Tertiary Coma X', ...
+                'Tertiary Coma Y', ...
+                'Tertiary Spherical', ...
+                'Quadrafoil X', ...
+                'Quadrafoil Y', ...
+                'Secondary Trefoil X', ...
+                'Secondary Trefoil Y', ...
+                'Quaternary Astigmatism 0°', ...
+                'Quaternary Astigmatism 45°', ...
+                'Quaternary Coma X', ...
+                'Quaternary Coma Y', ...
+                'Quaternary Spherical', ...
+                'Pentafoil X', ...
+                'Pentafoil Y', ...
+                'Secondary Trefoil X (high)', ...
+                'Secondary Trefoil Y (high)', ...
+                'Secondary Quadrafoil X', ...
+                'Secondary Quadrafoil Y'
+            };
+
+            if n < 1 || n > 36
+                error('ZernikeUtils:invalidIndex', ...
+                    'Zernike index n must be 1-36, got %d', n);
+            end
+
+            name = names{n};
+        end
+
+        function M = zernikeMatrix(rho, theta, nTerms)
+            % zernikeMatrix - Build design matrix for Zernike fitting
+            %
+            % Parameters:
+            %   rho    - [Ny x Nx] radial coordinates (normalized 0-1)
+            %   theta  - [Ny x Nx] azimuthal coordinates (radians)
+            %   nTerms - number of Zernike terms to include (1-36)
+            %
+            % Returns:
+            %   M      - [Ny*Nx x nTerms] design matrix where M(:, n) = Z_n(rho, theta)
+
+            if nTerms < 1 || nTerms > 36
+                error('ZernikeUtils:invalidNTerms', ...
+                    'nTerms must be 1-36, got %d', nTerms);
+            end
+
+            % Reshape to column vectors for matrix construction
+            rho_col = rho(:);
+            theta_col = theta(:);
+            nPixels = length(rho_col);
+
+            % Build design matrix
+            M = zeros(nPixels, nTerms);
+            for n = 1:nTerms
+                M(:, n) = ZernikeUtils.zernike(n, rho_col, theta_col);
+            end
+        end
+    end
+end

--- a/+paraxial/init.m
+++ b/+paraxial/init.m
@@ -1,0 +1,29 @@
+function init()
+    % init - Initialize +paraxial package with convenient imports
+    %
+    % Usage:
+    %   paraxial.init()  % Call once at start of session
+    %
+    % This adds all +paraxial/ subdirectories to the path and optionally
+    % imports commonly used classes.
+    %
+    % Note: In MATLAB/Octave, adding +paraxial/ to path automatically
+    % makes all subpackages accessible via import paraxial.* or
+    % import paraxial.beams.* etc.
+
+    scriptPath = fileparts(mfilename('fullpath'));
+
+    % Add main package directory
+    addpath(scriptPath);
+
+    % Add all subpackages
+    addpath(fullfile(scriptPath, '+beams'));
+    addpath(fullfile(scriptPath, '+parameters'));
+    addpath(fullfile(scriptPath, '+computation'));
+    addpath(fullfile(scriptPath, '+propagation'));
+    addpath(fullfile(scriptPath, '+propagation', '+field'));
+    addpath(fullfile(scriptPath, '+propagation', '+rays'));
+    addpath(fullfile(scriptPath, '+visualization'));
+
+    fprintf('[+paraxial] Package initialized\n');
+end

--- a/setpaths.m
+++ b/setpaths.m
@@ -40,8 +40,8 @@ function setpaths()
     addpath(fullfile(scriptPath, '+paraxial', '+propagation', '+rays'));
     addpath(fullfile(scriptPath, '+paraxial', '+visualization'));
 
-    %% Utilities (retained in ParaxialBeams/)
-    addpath(fullfile(scriptPath, 'ParaxialBeams'));
+    %% +paraxial namespace package (must add parent dir so package resolution works)
+    addpath(scriptPath);
     addpath(fullfile(scriptPath, 'ParaxialBeams', 'Addons'));
 
     %% Legacy compatibility aliases

--- a/setpaths.m
+++ b/setpaths.m
@@ -3,12 +3,18 @@ function setpaths()
     % Call this function before using the library, or add the
     % individual directories to your path.
     %
-    % Modern structure (src/):
+    % DUAL-PATH SUPPORT:
+    % This function adds both the legacy 'src/' paths and the modern
+    % '+paraxial/' package paths. Users can choose which to use.
+    %
+    % Legacy structure (src/):
     %   addpath('src/beams');
     %   addpath('src/parameters');
-    %   addpath('src/propagation/field');
-    %   addpath('src/propagation/rays');
-    %   addpath('src/visualization');
+    %   ...
+    %
+    % Modern package (+paraxial/):
+    %   addpath('+paraxial');  % enables 'import paraxial.*'
+    %   import paraxial.beams.GaussianBeam
     %
     % Utilities (ParaxialBeams/):
     %   addpath('ParaxialBeams');
@@ -16,7 +22,7 @@ function setpaths()
 
     scriptPath = fileparts(mfilename('fullpath'));
 
-    % Modern library structure (src/)
+    %% Legacy library structure (src/) — backward compatibility
     addpath(fullfile(scriptPath, 'src', 'beams'));
     addpath(fullfile(scriptPath, 'src', 'parameters'));
     addpath(fullfile(scriptPath, 'src', 'computation'));
@@ -24,15 +30,25 @@ function setpaths()
     addpath(fullfile(scriptPath, 'src', 'propagation', 'rays'));
     addpath(fullfile(scriptPath, 'src', 'visualization'));
 
-    % Utilities (retained in ParaxialBeams/)
+    %% Modern +paraxial/ package structure
+    addpath(fullfile(scriptPath, '+paraxial'));
+    addpath(fullfile(scriptPath, '+paraxial', '+beams'));
+    addpath(fullfile(scriptPath, '+paraxial', '+parameters'));
+    addpath(fullfile(scriptPath, '+paraxial', '+computation'));
+    addpath(fullfile(scriptPath, '+paraxial', '+propagation'));
+    addpath(fullfile(scriptPath, '+paraxial', '+propagation', '+field'));
+    addpath(fullfile(scriptPath, '+paraxial', '+propagation', '+rays'));
+    addpath(fullfile(scriptPath, '+paraxial', '+visualization'));
+
+    %% Utilities (retained in ParaxialBeams/)
     addpath(fullfile(scriptPath, 'ParaxialBeams'));
     addpath(fullfile(scriptPath, 'ParaxialBeams', 'Addons'));
 
-    % Legacy compatibility aliases
+    %% Legacy compatibility aliases
     addpath(fullfile(scriptPath, 'legacy', 'compat'));
 
-    % Tests
+    %% Tests
     addpath(fullfile(scriptPath, 'tests'));
 
-    fprintf('Path configured for Simulation_Scripts\n');
+    fprintf('Path configured for Simulation_Scripts (dual-path: src/ + +paraxial/)\n');
 end


### PR DESCRIPTION
## Summary
- Created +paraxial/ directory structure with namespaced classes organized into subpackages: +beams/, +parameters/, +propagation/+field/, +propagation/+rays/, +computation/, +visualization/
- Added +paraxial/init.m convenience initializer
- Updated setpaths.m for dual-path mode (src/ + +paraxial/)

## Motivation
First step of Post-Merge Track 3: +paraxial package migration. Dual-path approach maintains backward compatibility while providing modern namespaced classes.