### PR TITLE
ci: add benchmark baseline job to Octave CI workflow

### DIFF
--- a/.github/workflows/octave.yml
+++ b/.github/workflows/octave.yml
@@ -63,3 +63,38 @@ jobs:
           name: legacy-compat-log
           path: legacy-compat.log
           retention-days: 14
+
+  benchmark:
+    name: benchmark-baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Octave
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y octave
+
+      - name: Run quick benchmark
+        run: |
+          set -o pipefail
+          octave --no-gui --eval "addpath('tests/performance'); run_benchmarks('quick');" 2>&1 | tee benchmark.log
+
+      - name: Upload baseline CSV
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-baseline
+          path: docs/performance/baseline_quick_*.csv
+          retention-days: 30
+
+      - name: Upload benchmark log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-log
+          path: benchmark.log
+          retention-days: 14


### PR DESCRIPTION
## Summary
- Add `benchmark` job to `.github/workflows/octave.yml` to generate performance baseline via GitHub Actions
- Runs `run_benchmarks('quick')` in Octave
- Uploads baseline CSV artifact for retrieval

## Changes
| File | Change |
|------|--------|
| `.github/workflows/octave.yml` | Added `benchmark-baseline` job to run quick benchmark and upload CSV artifact |

## Test Plan
- [x] YAML syntax validated by GitHub Actions on push
- [ ] Workflow runs `benchmark` job on this PR (triggered by `workflow_dispatch`)
- [ ] Baseline CSV artifact appears in workflow run artifacts
- [ ] CSV contains scenario results (gaussian_fft_small, gaussian_analytic_small, gaussian_raytrace_small)

## Contributor Checklist
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers