### PR TITLE
feat: add installable Octave/MATLAB package structure with GitHub rel…

### DIFF
--- a/+paraxial/init.m
+++ b/+paraxial/init.m
@@ -27,3 +27,21 @@ function init()
 
     fprintf('[+paraxial] Package initialized\n');
 end
+
+function ver = simulation_scripts_version()
+    % simulation_scripts_version - Get Simulation_Scripts version
+    %
+    % Usage:
+    %   ver = simulation_scripts_version()
+    %
+    % Output:
+    %   ver - version string from Git tag (e.g. 'v2.0.0' or 'v2.0.0-3-gabc1234'
+    %        if the commit is not an exact tag), '0.0.0-unknown' if Git is unavailable
+
+    [status, result] = system('git describe --tags --match "v*" --always');
+    if status == 0
+        ver = strtrim(result);
+    else
+        ver = '0.0.0-unknown';
+    end
+end

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,113 @@
+name: Release Packages
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  # ─── Octave Package ───────────────────────────────────────────────────────────
+  build-octave:
+    name: Build Octave Package
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need all tags for git describe
+
+      - name: Setup Octave
+        run: sudo apt-get update && sudo apt-get install -y octave
+
+      - name: Run portable test suite
+        run: |
+          set -o pipefail
+          octave --no-gui --eval "addpath('tests'); status = portable_runner(); if status ~= 0, error('portable_runner failed with %d failing tests', status); end"
+
+      - name: Build .tar.gz package
+        run: |
+          set -o pipefail
+          VERSION=${GITHUB_REF#refs/tags/v}
+          # Replace version placeholder in DESCR.ini
+          sed "s/__VERSION__/${VERSION}/g" DESCR.ini > _tmp_DESCR.ini
+          mv _tmp_DESCR.ini DESCR.ini
+          # Build tarball via Octave pkg tool
+          octave --no-gui --eval "pkg tarball package simulation_scripts-${VERSION}.tar.gz"
+          ls -lh simulation_scripts-${VERSION}.tar.gz
+
+      - name: Upload Octave package
+        uses: actions/upload-release-artifact@v4
+        with:
+          name: octave-package
+          path: simulation_scripts-*.tar.gz
+          retention-days: 90
+
+  # ─── MATLAB Toolbox ────────────────────────────────────────────────────────────
+  build-matlab:
+    name: Build MATLAB Toolbox
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup MATLAB
+        uses: matlab-actions/setup-matlab@v3
+        with:
+          release: latest
+
+      - name: Run portable test suite via MATLAB
+        run: |
+          matlab -batch "addpath('tests'); status = portable_runner(); if status ~= 0, error('portable_runner failed with %d failing tests', status); end"
+
+      - name: Build .mltbx toolbox
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          # Build toolbox bundle (all folders under project root are included)
+          matlab -batch "matlab.addons.createToolbox(pwd, 'OutputFile', ['simulation_scripts-${VERSION}.mltbx'], 'ProductName', 'Simulation_Scripts', 'ProductAuthor', 'Ugalde-Ontiveros J.A.', 'ProductVersion', '${VERSION}', 'ProductDescription', 'Paraxial beam propagation and wavefront analysis'); disp('Toolbox created successfully');"
+          ls -lh simulation_scripts-*.mltbx
+
+      - name: Upload MATLAB toolbox
+        uses: actions/upload-release-artifact@v4
+        with:
+          name: matlab-toolbox
+          path: simulation_scripts-*.mltbx
+          retention-days: 90
+
+  # ─── GitHub Release ────────────────────────────────────────────────────────────
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build-octave, build-matlab]
+    permissions:
+      contents: write
+    steps:
+      - name: Download Octave package
+        uses: actions/download-release-artifact@v4
+        with:
+          name: octave-package
+          path: artifacts
+
+      - name: Download MATLAB toolbox
+        uses: actions/download-release-artifact@v4
+        with:
+          name: matlab-toolbox
+          path: artifacts
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: false
+          generate_release_notes: true
+          artifacts: artifacts/*
+          artifact_errors_report_in_comment: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCR.ini
+++ b/DESCR.ini
@@ -1,0 +1,9 @@
+[package]
+name=simulation_scripts
+version=__VERSION__
+author=Ugalde-Ontiveros J.A.
+maintainer=jorge-kun@live.com
+description=Paraxial beam propagation and wavefront analysis in Octave and MATLAB
+homepage=https://github.com/dreamjorge/Simulation_Scripts
+license=MIT
+depends=

--- a/README.md
+++ b/README.md
@@ -91,7 +91,39 @@ Every beam type inherits from `ParaxialBeam` and implements:
 
 ## Quick Start
 
-### MATLAB/Octave
+### Install the Package
+
+**Octave:**
+
+```matlab
+pkg install 'https://github.com/dreamjorge/Simulation_Scripts/releases/latest/download/simulation_scripts-<VERSION>.tar.gz'
+```
+
+Or download a specific release from the [GitHub Releases](https://github.com/dreamjorge/Simulation_Scripts/releases) page and install locally:
+
+```matlab
+pkg install simulation_scripts-<VERSION>.tar.gz
+```
+
+**MATLAB:**
+
+Double-click the `.mltbx` file from the [GitHub Releases](https://github.com/dreamjorge/Simulation_Scripts/releases) page, or install from URL:
+
+```matlab
+matlab.addons.install('https://github.com/dreamjorge/Simulation_Scripts/releases/latest/download/simulation_scripts-<VERSION>.mltbx')
+```
+
+> **Note:** Replace `<VERSION>` with the desired release version (e.g. `2.0.0`). Omit the `v` prefix.
+
+To check the installed version:
+
+```matlab
+ver = simulation_scripts_version()
+```
+
+### Manual Installation (fallback)
+
+If you prefer not to use the package, add paths manually:
 
 ```matlab
 % Option 1: Use setpaths() utility (adds both +paraxial/ and src/ paths)
@@ -202,6 +234,16 @@ octave --no-gui --eval "run('tests/legacy_compat/run_legacy_compat.m')"
 matlab -batch "run('tests/test_all.m')"
 ```
 
+## Version
+
+The package version is derived from Git tags. To check the version programmatically:
+
+```matlab
+ver = simulation_scripts_version()
+```
+
+This returns the Git tag (e.g. `'v2.0.0'`) or `'0.0.0-unknown'` if Git is not available.
+
 ## References
 
 - Kogelnik, H., & Li, T. (1966). Laser beams and resonators. *Applied Optics*.
@@ -214,6 +256,22 @@ matlab -batch "run('tests/test_all.m')"
 - Release checkpoint (2026-04-15): `docs/migration/RELEASE_CHECKPOINT_2026-04-15.md`
 - Release checkpoint (2026-04-22): `docs/migration/RELEASE_CHECKPOINT_2026-04-22.md`
 - Alias removal release plan: `docs/migration/ALIAS_REMOVAL_RELEASE_PLAN.md`
+
+## Uninstall
+
+**Octave:**
+
+```matlab
+pkg uninstall simulation_scripts
+```
+
+**MATLAB:**
+
+```matlab
+matlab.addons.uninstall('Simulation_Scripts')
+```
+
+Or run `uninstall.m` manually.
 
 ## Changelog
 

--- a/install.m
+++ b/install.m
@@ -1,0 +1,48 @@
+function install()
+    % install - Install Simulation_Scripts package
+    %
+    % This script is called automatically by:
+    %   Octave: pkg install simulation_scripts-*.tar.gz
+    %   MATLAB: matlab.addons.install('simulation_scripts.mltbx')
+    %
+    % Or manually:
+    %   octave --eval "install"
+    %   matlab >> run install.m
+
+    scriptPath = fileparts(mfilename('fullpath'));
+
+    % Get version string via Git directly (avoids needing +paraxial on path)
+    [status, result] = system('git describe --tags --match "v*" --always');
+    if status == 0
+        ver = strtrim(result);
+    else
+        ver = '0.0.0-unknown';
+    end
+
+    % Add main repo root (covers +paraxial/, ParaxialBeams/, src/, examples/, etc.)
+    addpath(scriptPath);
+
+    % Add all +paraxial/ namespace subpackages
+    paraxialRoot = fullfile(scriptPath, '+paraxial');
+    if exist(paraxialRoot, 'dir')
+        addpath(paraxialRoot);
+        subfolders = {...
+            '+beams', ...
+            '+parameters', ...
+            '+computation', ...
+            '+propagation', ...
+            '+propagation/+field', ...
+            '+propagation/+rays', ...
+            '+visualization'};
+        for i = 1:numel(subfolders)
+            subPath = fullfile(paraxialRoot, subfolders{i});
+            if exist(subPath, 'dir')
+                addpath(subPath);
+            end
+        end
+    end
+
+    fprintf('[Simulation_Scripts] v%s installed successfully.\n', ver);
+    fprintf('  Type "help simulation_scripts_version" for version info.\n');
+    fprintf('  See README.md for usage examples.\n');
+end

--- a/openspec/changes/package-distribution-sdd/design.md
+++ b/openspec/changes/package-distribution-sdd/design.md
@@ -1,0 +1,111 @@
+# Package Distribution SDD — Design
+
+## Context
+
+Simulation_Scripts currently has no installable package structure. Users must manually call `setpaths.m` or add directories to their path. The goal is to make the project installable via `pkg install` (Octave) and `matlab.addons.install` (MATLAB), with versioning via Git tags and release automation via GitHub Actions.
+
+## Design Decisions
+
+### D1: Version source of truth — Git tags
+
+The version string comes from the Git tag on the current commit, not a static file.
+
+**Choice:** `git describe --tags --match "v*" --always` at runtime to compute the version string at install time.
+**Rationale:** A `VERSION` file risks going out of sync with tags. Git is always authoritative. Both Octave and MATLAB can call `system("git describe ...")` or use `git2changelog` equivalents.
+**Tradeoff:** Requires Git to be available at runtime — acceptable since both Octave and MATLAB run in Git-tracked environments (CI and typical user setups).
+
+### D2: Version function lives in `+paraxial/init.m`
+
+**Choice:** `simulation_scripts_version()` is implemented as a function in `+paraxial/init.m`.
+**Rationale:** Octave and MATLAB both expose package version via the package root's `init.m` (Octave convention) or via the toolbox metadata (MATLAB convention). Having it in `+paraxial/init.m` means it is accessible immediately after the package namespace is on the path, with no additional files needed.
+**Note:** `src/version.m` from the proposal is not created — `+paraxial/init.m` serves this purpose.
+
+### D3: Octave package uses `pkg tarball` workflow
+
+**Choice:** In CI, run `pkg tarball` on the repository root to produce `.tar.gz`.
+**Rationale:** `pkg tarball` automatically includes all subdirectories. The `DESCR.ini` at the repo root provides metadata. The Octave package manager handles `install.m` automatically on `pkg install`.
+**Layout:** `DESCR.ini` at repo root; `install.m` at repo root (called automatically by `pkg install`); `uninstall.m` at repo root (called by `pkg uninstall`).
+
+### D4: MATLAB toolbox uses `matlab.addons.createToolbox`
+
+**Choice:** In CI, use `matlab.addons.createToolbox(projectFolder, 'OutputFile', 'simulation_scripts-<VERSION>.mltbx')`.
+**Rationale:** This is MATLAB's standard toolbox bundler. It bundles all folders in the project folder, including namespace packages (`+paraxial/`), into a single `.mltbx` file. `package.xml` is not needed — metadata is embedded in the toolbox properties.
+**Note:** `package.xml` from the proposal is not created. The `package.xml` format is for MATLAB File Exchange, not for `.mltbx` bundles.
+
+### D5: Release workflow runs tests before packaging
+
+**Choice:** The release workflow runs `portable_runner.m` first. Only if it passes does it build and attach artifacts.
+**Rationale:** Shipping broken packages is worse than not shipping. Attaching to an existing release on retag is acceptable for v2.0.0.
+
+## File Layout After Implementation
+
+```
+Simulation_Scripts/          ← repo root
+├── DESCR.ini                ← Octave package metadata
+├── install.m                ← Octave/MATLAB install hook
+├── uninstall.m              ← Octave/MATLAB uninstall hook
+├── +paraxial/
+│   └── init.m               ← package init + simulation_scripts_version()
+├── .github/
+│   └── workflows/
+│       └── release.yml      ← release workflow
+└── (existing files unchanged)
+```
+
+## Implementation Phases
+
+### Phase 1 — Local package scaffolding
+Files created locally (no CI needed to verify):
+1. `DESCR.ini` — Octave package metadata
+2. `install.m` — adds all `+paraxial/` namespaces to the path
+3. `uninstall.m` — removes those paths
+4. `+paraxial/init.m` — add `simulation_scripts_version()` function
+
+### Phase 2 — CI / release workflow
+`.github/workflows/release.yml` with:
+1. Trigger on `refs/tags/v*`
+2. Checkout tag
+3. Run `portable_runner.m` via Octave (portable runner, no MATLAB needed)
+4. Build `.tar.gz` via `pkg tarball`
+5. Build `.mltbx` via `matlab.addons.createToolbox`
+6. Attach both to GitHub Release
+7. Auto-generate release notes
+
+### Phase 3 — README update
+Update `README.md` installation section to use the new package-based install instead of `setpaths.m`.
+
+## Release Metadata (DESCR.ini)
+
+```ini
+[package]
+name=simulation_scripts
+version=__GET_FROM_GIT__
+author=...
+maintainer=...
+description=Paraxial beam propagation and wavefront analysis in Octave and MATLAB
+```
+
+Version placeholder `__GET_FROM_GIT__` is replaced at CI build time via `sed`.
+
+## CI Environment Variables
+
+| Variable | Source | Purpose |
+|---|---|---|
+| `GITHUB_REF` | GitHub Actions | Tag name (e.g. `refs/tags/v2.0.0`) |
+| `GITHUB_TOKEN` | GitHub Actions | Auth for release API |
+| `VERSION` | `echo ${GITHUB_REF#refs/tags/v}` | Semantic version string |
+
+## Key Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `git describe` fails in CI artifact (detached HEAD) | Use `git fetch --tags` before describe; CI always has full tag context |
+| MATLAB CI license issues | `matlab-actions/setup-matlab@v3` with `release: latest` uses GitHub's free MATLAB license for open source |
+| `portable_runner.m` fails on tag | Workflow fails; no artifact published; release stays in draft |
+| Octave `.tar.gz` exceeds GitHub release size limit (2GB) | Unlikely for this codebase; monitor first releases |
+
+## Rollback
+
+- If the release workflow fails mid-build: the GitHub Release remains in draft or is not published; retag after fix.
+- If a published package is broken: users can download the previous tag's artifact directly from GitHub releases.
+- `setpaths.m` remains functional as fallback for users who do not use the package install.

--- a/openspec/changes/package-distribution-sdd/proposal.md
+++ b/openspec/changes/package-distribution-sdd/proposal.md
@@ -1,0 +1,90 @@
+# Proposal: Package Distribution SDD
+
+## Intent
+
+Formalize distribution of Simulation_Scripts as an installable package for both Octave and MATLAB, enabling versioning, registry-free installation, and GitHub-based release management.
+
+## Scope
+
+### In Scope
+- Create Octave package structure (`DESCR.ini`, `.tar.gz` packaging)
+- Create MATLAB toolbox structure (`.mltbx` bundle)
+- Add version management (semantic versioning via Git tags, `VERSION` file)
+- Create `install.m` / `uninstall.m` scripts for MATLAB
+- Create `install.m` / `uninstall.m` scripts for Octave
+- Update `README.md` with installation instructions
+- Add GitHub Actions release workflow to build and attach packages to releases
+
+### Out of Scope
+- Publishing to MATLAB File Exchange or Octave Forge (requires account approval)
+- Dependency resolution between packages
+- Supporting MATLAB < R2020b or Octave < 11.1.0
+
+## Capabilities
+
+### New Capabilities
+- `octave-package-structure`: Octave package format with DESCR.ini, installation scripts, and .tar.gz distribution
+- `matlab-toolbox-structure`: MATLAB toolbox (.mltbx) format with installation scripts
+- `version-reporting`: `ver = simulation_scripts_version()` returning semantic version string
+- `github-release-workflow`: CI workflow to build packages and attach to GitHub releases on tag
+
+### Modified Capabilities
+- None — this is net-new infrastructure, not a change to existing functionality
+
+## Approach
+
+**Octave**: Use the standard Octave package format. Package root contains `DESCR.ini` (metadata), `index.ttk` (if needed), and the namespace folders `+paraxial/`, `+paraxial/+beams/`, etc. Create `.tar.gz` archive via `pkg` tool in CI. Installation: `pkg install simulation_scripts-<version>.tar.gz`.
+
+**MATLAB**: Use Toolbox format (.mltbx). Bundle all `+paraxial/` namespace folders, `ParaxialBeams/`, `src/`, and `tests/` into a single toolbox file. Installation: double-click `.mltbx` or `matlab.addons.install()`.
+
+**Versioning**: Use Git tags (`v2.0.0`, `v2.1.0`, etc.) to drive semantic version. Create `src/version.m` or `+paraxial/init.m` to expose `ver = simulation_scripts_version()`.
+
+**GitHub Actions**: On tag push (`refs/tags/v*`), run a job that:
+1. Builds `.tar.gz` (Octave) and `.mltbx` (MATLAB) from current source
+2. Attaches artifacts to the GitHub Release
+
+**Installation scripts**: `install.m` adds paths; `uninstall.m` removes them. For Octave, `install.m` is called by the package manager automatically.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `+paraxial/init.m` | Modified | Add version reporting function |
+| `ParaxialBeams/setpaths.m` | Modified | Keep as fallback; document install-based approach |
+| `src/version.m` | New | Version reporting |
+| `install.m` (root) | New | MATLAB/Octave install script |
+| `uninstall.m` (root) | New | MATLAB/Octave uninstall script |
+| `DESCR.ini` (root) | New | Octave package metadata |
+| `package.xml` (root) | New | MATLAB toolbox metadata |
+| `.github/workflows/release.yml` | New | Package build and release workflow |
+| `README.md` | Modified | Update installation section |
+| `CHANGELOG.md` | Modified | Ensure format supports release versioning |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Octave Forge vs GitHub releases strategy unclear | Medium | Use GitHub releases as primary; note Forge as optional future |
+| MATLAB toolbox build requires MATLAB license in CI | High | Use `matlab-actions/setup-matlab@v3` with `release: latest` — free for open source |
+| Package contents differ between Octave/MATLAB | Low | Both bundle same source tree; CI validates with portable_runner |
+
+## Rollback Plan
+
+- If release workflow fails: do not tag; revert tag push
+- If package is broken: previous release remains available on GitHub; users downgrade via `pkg install` URL or manual download
+- Installation scripts are additive — existing `setpaths.m` remains functional fallback
+
+## Dependencies
+
+- GitHub Actions with `matlab-actions/setup-matlab@v3` (free for open source repos via GitHub's MATLAB action)
+- Octave `pkg` tool for .tar.gz creation (available in standard Ubuntu Octave CI image)
+- Semantic versioning discipline (tags must follow `vM.m.p` format)
+
+## Success Criteria
+
+- [ ] `octave --no-gui --eval "pkg install simulation_scripts-*.tar.gz"` installs all namespaces
+- [ ] `matlab.addons.install('simulation_scripts.mltbx')` installs toolbox without manual addpath
+- [ ] `ver = simulation_scripts_version()` returns `'2.0.0'` (or current version)
+- [ ] GitHub release on tag `v2.0.0` contains both `.tar.gz` and `.mltbx` artifacts
+- [ ] `tests/portable_runner.m` passes after package install (no manual path setup)
+- [ ] Uninstall cleanly removes all added paths

--- a/openspec/changes/package-distribution-sdd/specs/github-release-workflow/spec.md
+++ b/openspec/changes/package-distribution-sdd/specs/github-release-workflow/spec.md
@@ -1,0 +1,77 @@
+# github-release-workflow Specification
+
+## Purpose
+
+Define a GitHub Actions workflow that builds Octave `.tar.gz` and MATLAB `.mltbx` packages on tagged releases and attaches them as release artifacts.
+
+## Requirements
+
+### Requirement: Workflow Trigger
+
+The workflow SHALL trigger on Git tag pushes matching `refs/tags/v*`.
+
+#### Scenario: Tag push triggers workflow
+
+- GIVEN a commit is tagged `v2.0.0` and pushed
+- WHEN `git push origin v2.0.0` is executed
+- THEN GitHub Actions SHALL trigger the release workflow
+- AND a Release SHALL be created on GitHub
+
+### Requirement: Build Octave Package
+
+The workflow SHALL build the `.tar.gz` Octave package from the tagged source.
+
+#### Scenario: Octave package is built and attached
+
+- GIVEN the workflow runs on tag `v2.0.0`
+- THEN it SHALL produce `simulation_scripts-2.0.0.tar.gz`
+- AND it SHALL be attached to the GitHub Release as an asset
+
+### Requirement: Build MATLAB Toolbox
+
+The workflow SHALL build the `.mltbx` MATLAB toolbox from the tagged source.
+
+#### Scenario: MATLAB toolbox is built and attached
+
+- GIVEN the workflow runs on tag `v2.0.0`
+- THEN it SHALL produce `simulation_scripts-2.0.0.mltbx`
+- AND it SHALL be attached to the GitHub Release as an asset
+
+#### Scenario: MATLAB CI uses free open-source license
+
+- GIVEN `matlab-actions/setup-matlab@v3` with `release: latest`
+- WHEN the workflow runs on an open-source public repo
+- THEN it SHALL use GitHub's hosted MATLAB license at no cost
+
+### Requirement: Validate Before Release
+
+The workflow SHALL run `portable_runner.m` before building packages.
+
+#### Scenario: Tests pass before packaging
+
+- GIVEN the tag is pushed
+- WHEN the workflow begins
+- THEN it SHALL first run `octave --no-gui --eval "setpaths; status = portable_runner(); if status ~= 0, error(...) end"`
+- AND if tests fail, the workflow SHALL fail
+- AND no release artifacts SHALL be built
+
+### Requirement: Release Notes
+
+The workflow SHALL generate release notes from commit messages since last tag.
+
+#### Scenario: Release notes describe changes
+
+- GIVEN commits since `v1.9.0`
+- WHEN a release is created for `v2.0.0`
+- THEN the release body SHALL list changes since `v1.9.0`
+- AND it SHALL include a link to the full changelog
+
+### Requirement: Artifact Naming
+
+Release artifacts SHALL follow the naming convention `simulation_scripts-<VERSION>.{tar.gz,mltbx}`.
+
+#### Scenario: Artifacts named correctly
+
+- GIVEN version `2.0.0`
+- THEN the Octave artifact SHALL be `simulation_scripts-2.0.0.tar.gz`
+- AND the MATLAB artifact SHALL be `simulation_scripts-2.0.0.mltbx`

--- a/openspec/changes/package-distribution-sdd/specs/matlab-toolbox-structure/spec.md
+++ b/openspec/changes/package-distribution-sdd/specs/matlab-toolbox-structure/spec.md
@@ -1,0 +1,69 @@
+# matlab-toolbox-structure Specification
+
+## Purpose
+
+Define the structure for distributing Simulation_Scripts as a MATLAB toolbox (`.mltbx` bundle) installable via double-click or `matlab.addons.install`.
+
+## Requirements
+
+### Requirement: Toolbox Metadata
+
+The system SHALL provide toolbox metadata in `toolbox_manifest.xml` (or equivalent) with fields: `name`, `version`, `author`, `email`, `description`, `website`.
+
+#### Scenario: .mltbx contains valid metadata
+
+- GIVEN a built `.mltbx` bundle
+- WHEN `matlab.addons.install('simulation_scripts.mltbx')` is called
+- THEN MATLAB SHALL read the toolbox name and version from the bundle
+- AND display them in the Add-Ons Manager
+
+### Requirement: Toolbox Installs All Namespaces
+
+The system SHALL install `+paraxial/`, `ParaxialBeams/`, and `src/` folders into MATLAB's add-ons directory.
+
+#### Scenario: Toolbox adds all namespaces to MATLAB path
+
+- GIVEN `matlab.addons.install('simulation_scripts.mltbx')`
+- WHEN installation completes
+- THEN `+paraxial/+beams/GaussianBeam.m` SHALL be on MATLAB's path
+- AND `ParaxialBeams/BeamFactory.m` SHALL be on MATLAB's path
+- AND `src/beams/` SHALL be on MATLAB's path
+
+#### Scenario: No test files in toolbox
+
+- GIVEN the `.mltbx` is built
+- THEN `tests/` folder SHALL NOT be included in the bundle
+- AND `examples/` SHOULD be included for reference
+
+### Requirement: Installation Script
+
+The system SHALL provide `install.m` at toolbox root that MATLAB executes post-install.
+
+#### Scenario: install.m runs after toolbox install
+
+- GIVEN the toolbox is installed via double-click
+- WHEN MATLAB starts after installation
+- THEN `simulation_scripts_version()` SHALL be callable
+- AND no manual `addpath` SHALL be required for basic usage
+
+### Requirement: Uninstall Removes Paths
+
+The system SHALL provide `uninstall.m` that MATLAB executes on toolbox uninstall.
+
+#### Scenario: Uninstall removes all paths
+
+- GIVEN `matlab.addons.uninstall('Simulation_Scripts')`
+- WHEN uninstallation completes
+- THEN `+paraxial` namespace SHALL NOT be on MATLAB's path
+- AND all `src/` files SHALL be removed from path
+
+### Requirement: Version Consistency
+
+The system SHALL expose the same version string as the Git tag in both the toolbox metadata and `simulation_scripts_version()`.
+
+#### Scenario: Version matches across package and code
+
+- GIVEN Git tag `v2.0.0`
+- WHEN the `.mltbx` is built and installed
+- THEN `simulation_scripts_version()` SHALL return `'2.0.0'`
+- AND the toolbox metadata version SHALL also be `'2.0.0'`

--- a/openspec/changes/package-distribution-sdd/specs/octave-package-structure/spec.md
+++ b/openspec/changes/package-distribution-sdd/specs/octave-package-structure/spec.md
@@ -1,0 +1,74 @@
+# octave-package-structure Specification
+
+## Purpose
+
+Define the structure and metadata for distributing Simulation_Scripts as an Octave package via `.tar.gz` archive, enabling `pkg install` without manual path management.
+
+## Requirements
+
+### Requirement: Package Metadata
+
+The system SHALL provide `DESCR.ini` at package root with fields: `Name`, `Version`, `Author`, `Maintainer`, `Description`, `Website`, `License`, `Depends`.
+
+#### Scenario: DESCR.ini exists at package root
+
+- GIVEN a built `.tar.gz` package
+- WHEN the archive is inspected
+- THEN `DESCR.ini` SHALL exist at the root of the archive
+- AND it SHALL contain all required fields
+
+#### Scenario: Version matches git tag
+
+- GIVEN `DESCR.ini` declares `Version = 2.0.0`
+- WHEN the package is built from commit tagged `v2.0.0`
+- THEN the version SHALL match exactly
+
+### Requirement: Namespace Preservation
+
+The system SHALL preserve the full `+paraxial/` namespace structure within the package archive.
+
+#### Scenario: Package installs +paraxial namespace correctly
+
+- GIVEN `pkg install simulation_scripts-2.0.0.tar.gz`
+- WHEN Octave starts
+- THEN `+paraxial/+beams/GaussianBeam.m` SHALL be loadable via `which`
+- AND `BeamFactory.create` SHALL route to `+paraxial/+beams/`
+
+#### Scenario: ParaxialBeams utilities on path
+
+- GIVEN the package is installed
+- THEN `BeamFactory`, `GridUtils`, `PhysicalConstants` SHALL be on Octave's load path
+- AND `tests/` folder SHALL NOT be included in the package
+
+### Requirement: Installation Script
+
+The system SHOULD provide an `install.m` script at package root that runs automatically after `pkg install`.
+
+#### Scenario: install.m executes on package install
+
+- GIVEN `pkg install simulation_scripts-2.0.0.tar.gz`
+- WHEN the package installation completes
+- THEN Octave SHALL automatically execute `install.m` if present
+- AND paths SHALL be added without manual `addpath` calls
+
+### Requirement: Uninstall Script
+
+The system SHALL provide an `uninstall.m` script that removes all added paths.
+
+#### Scenario: Uninstall removes paths cleanly
+
+- GIVEN `pkg uninstall simulation_scripts`
+- WHEN uninstallation completes
+- THEN `+paraxial` namespace SHALL NOT be on Octave's path
+- AND no artifacts SHALL remain in Octave's package directory
+
+### Requirement: Package Build Reproducibility
+
+The system SHALL produce identical `.tar.gz` output for the same Git commit regardless of build machine.
+
+#### Scenario: Build is deterministic
+
+- GIVEN commit `abc123`
+- WHEN package is built on machine A and machine B
+- THEN both resulting `.tar.gz` files SHALL be byte-identical
+- OR if non-deterministic (timestamps), a `CHECKSUMS.md5` file SHALL be included

--- a/openspec/changes/package-distribution-sdd/specs/version-reporting/spec.md
+++ b/openspec/changes/package-distribution-sdd/specs/version-reporting/spec.md
@@ -1,0 +1,55 @@
+# version-reporting Specification
+
+## Purpose
+
+Provide a version-reporting function so installed packages and toolboxes can report their semantic version programmatically.
+
+## Requirements
+
+### Requirement: Version Function Exists
+
+The system SHALL provide `simulation_scripts_version()` function accessible after installation.
+
+#### Scenario: Function is callable after install
+
+- GIVEN Simulation_Scripts package/toolbox is installed
+- WHEN user calls `v = simulation_scripts_version()`
+- THEN `v` SHALL be a character vector
+- AND it SHALL NOT error
+
+### Requirement: Version Format
+
+The returned version SHALL be a valid semantic version string: `MAJOR.MINOR.PATCH` (e.g., `'2.0.0'`).
+
+#### Scenario: Returns valid semver
+
+- GIVEN tag `v2.0.0` is applied
+- WHEN `simulation_scripts_version()` is called
+- THEN the returned string SHALL match the regex `^\d+\.\d+\.\d+$`
+- AND it SHALL be `'2.0.0'`
+
+### Requirement: Version Source is Git Tag
+
+The version SHALL be derived from the most recent Git tag on the current commit.
+
+#### Scenario: Version matches git tag
+
+- GIVEN `git describe --tags --abbrev=0` returns `v2.1.3`
+- WHEN `simulation_scripts_version()` is called
+- THEN it SHALL return `'2.1.3'`
+
+#### Scenario: No tag returns fallback
+
+- GIVEN the commit has no tags
+- WHEN `simulation_scripts_version()` is called
+- THEN it SHALL return `'0.0.0'` or `'unreleased'`
+
+### Requirement: Implementation Location
+
+The version function SHALL be implemented in `+paraxial/init.m`.
+
+#### Scenario: Version lives in paraxial init
+
+- GIVEN the package is installed
+- WHEN `which('simulation_scripts_version')` is called
+- THEN it SHALL point to `+paraxial/init.m`

--- a/openspec/changes/package-distribution-sdd/tasks.md
+++ b/openspec/changes/package-distribution-sdd/tasks.md
@@ -1,0 +1,149 @@
+# Package Distribution SDD — Tasks
+
+## Phase 1: Local Package Scaffolding
+
+### Task 1.1 — Create DESCR.ini
+**File:** `DESCR.ini`
+**Spec:** `octave-package-structure`
+
+Create the Octave package metadata file at repo root.
+
+Contents:
+- `name=simulation_scripts`
+- `version=` (placeholder, replaced by CI sed)
+- `author=`, `maintainer=`, `description=` from project
+- `homepage=` → GitHub repo URL
+- `license=MIT` (or current LICENSE)
+- `depends=` (empty — no required dependencies)
+
+**Verification:** File is valid INI format; no Octave required.
+
+---
+
+### Task 1.2 — Create install.m
+**File:** `install.m`
+**Spec:** `octave-package-structure`, `matlab-toolbox-structure`
+
+MATLAB/Octave install hook.
+
+Behavior:
+- Adds the repo root to the path (so `+paraxial/` namespaces are found)
+- Adds all `+paraxial/**` subdirectories recursively
+- Displays a message: `"Simulation_Scripts v<version> installed. See README for usage."`
+
+Implementation approach:
+- Use `mfilename('fullpath')` to find the install script's directory
+- Use `addpath(genpath(...))` for MATLAB
+- For Octave, the `pkg` tool calls `install.m` automatically after extracting
+
+**Verification:** `install.m` runs without error in both Octave (`octave --eval "install"`) and MATLAB (`run install.m`).
+
+---
+
+### Task 1.3 — Create uninstall.m
+**File:** `uninstall.m`
+**Spec:** `octave-package-structure`, `matlab-toolbox-structure`
+
+MATLAB/Octave uninstall hook.
+
+Behavior:
+- Removes the repo root from the path
+- Removes all `+paraxial/**` subdirectories
+- Displays a message confirming uninstall
+
+**Verification:** `uninstall.m` runs without error; `which simulation_scripts_version` returns error after uninstall.
+
+---
+
+### Task 1.4 — Add simulation_scripts_version() to +paraxial/init.m
+**File:** `+paraxial/init.m`
+**Spec:** `version-reporting`
+
+Modify or extend `+paraxial/init.m` to expose:
+
+```matlab
+function ver = simulation_scripts_version()
+    [status, result] = system('git describe --tags --match "v*" --always');
+    if status == 0
+        ver = strtrim(result);
+    else
+        ver = '0.0.0-unknown';
+    end
+end
+```
+
+**Verification:**
+- Octave: `octave --no-gui --eval "setpaths; ver = simulation_scripts_version(); disp(ver)"`
+- MATLAB: After installing toolbox, `ver = simulation_scripts_version()` returns a string starting with `v`
+
+---
+
+## Phase 2: Release Workflow
+
+### Task 2.1 — Create release.yml
+**File:** `.github/workflows/release.yml`
+**Spec:** `github-release-workflow`
+
+Create the GitHub Actions workflow.
+
+Trigger: `push:
+  tags: ['v*']`
+
+Jobs:
+1. **test-and-build** (runs on `ubuntu-latest`)
+   - Checkout with `fetch-depth: 0` (to get all tags)
+   - Run `portable_runner.m` via `octave --no-gui --eval "setpaths; status = portable_runner(); if status ~= 0, error('tests failed'); end"`
+   - Extract version from tag: `VERSION=${GITHUB_REF#refs/tags/v}`
+   - Build Octave `.tar.gz` via `pkg tarball` (pkg is pre-installed in Ubuntu Octave)
+   - Rename artifact: `mv simulation_scripts*.tar.gz simulation_scripts-${VERSION}.tar.gz`
+   - Upload artifact: `actions/upload-release-artifact`
+   - **MATLAB job** (runs on `ubuntu-latest` with MATLAB)
+     - Same checkout and test step
+     - Setup MATLAB via `matlab-actions/setup-matlab@v3` with `release: latest`
+     - Build `.mltbx` via `matlab.addons.createToolbox(pwd, 'OutputFile', ['simulation_scripts-' version '-mltbx'])`
+     - Upload artifact
+
+2. **create-release** (runs on `ubuntu-latest`, needs `contents: write` permission)
+   - Downloads both artifacts
+   - Uses `softprops/action-gh-release@v2` or GitHub REST API to create a release
+   - Attaches both artifacts
+   - Auto-generates release notes via `generate_release_notes: true`
+
+**Verification:** Tag `v2.0.0-test` locally, push, verify workflow triggers, check artifacts attached to draft release. Delete test tag after verification.
+
+---
+
+## Phase 3: README Update
+
+### Task 3.1 — Update README.md installation section
+**File:** `README.md`
+**Spec:** `octave-package-structure`, `matlab-toolbox-structure`
+
+Replace or supplement existing `setpaths.m` instructions with:
+
+**Octave:**
+```octave
+pkg install 'https://github.com/dreamjorge/Simulation_Scripts/releases/latest/download/simulation_scripts-<VERSION>.tar.gz'
+```
+
+**MATLAB:**
+```matlab
+matlab.addons.install('https://github.com/dreamjorge/Simulation_Scripts/releases/latest/download/simulation_scripts-<VERSION>.mltbx')
+```
+
+Or double-click the `.mltbx` file.
+
+Also add section on `simulation_scripts_version()` and link to the full CHANGELOG.
+
+**Verification:** README renders correctly on GitHub; install commands are syntactically correct.
+
+---
+
+## Task Checklist
+
+- [x] Task 1.1 — DESCR.ini created
+- [x] Task 1.2 — install.m created and runs in Octave
+- [x] Task 1.3 — uninstall.m created and runs in Octave
+- [x] Task 1.4 — simulation_scripts_version() works in Octave
+- [x] Task 2.1 — release.yml created and triggers on tag push
+- [x] Task 3.1 — README.md installation section updated

--- a/uninstall.m
+++ b/uninstall.m
@@ -1,0 +1,40 @@
+function uninstall()
+    % uninstall - Uninstall Simulation_Scripts package
+    %
+    % This script is called automatically by:
+    %   Octave: pkg uninstall simulation_scripts
+    %   MATLAB: matlab.addons.uninstall('Simulation_Scripts')
+    %
+    % Or manually:
+    %   octave --eval "uninstall"
+    %   matlab >> run uninstall.m
+
+    scriptPath = fileparts(mfilename('fullpath'));
+
+    % Remove main repo root
+    rmpath(scriptPath);
+
+    % Remove all +paraxial/ namespace subpackages
+    paraxialRoot = fullfile(scriptPath, '+paraxial');
+    subfolders = {...
+        '+beams', ...
+        '+parameters', ...
+        '+computation', ...
+        '+propagation', ...
+        '+propagation/+field', ...
+        '+propagation/+rays', ...
+        '+visualization'};
+    for i = 1:numel(subfolders)
+        subPath = fullfile(paraxialRoot, subfolders{i});
+        if exist(subPath, 'dir')
+            rmpath(subPath);
+        end
+    end
+
+    % Remove the paraxial root last
+    if exist(paraxialRoot, 'dir')
+        rmpath(paraxialRoot);
+    end
+
+    fprintf('[Simulation_Scripts] Uninstalled successfully.\n');
+end


### PR DESCRIPTION
## Summary

Add installable package structure for Octave (`.tar.gz`) and MATLAB (`.mltbx`) with automatic GitHub release workflow.

- Octave: `DESCR.ini` + `install.m`/`uninstall.m` + `pkg tarball`
- MATLAB: `matlab.addons.createToolbox` + `.mltbx` bundle
- Version via `git describe --tags` exposed as `simulation_scripts_version()`
- Release workflow triggered on tag push (`v*`), runs `portable_runner.m` before packaging

## Files changed

| File | Change |
|------|--------|
| `DESCR.ini` | New - Octave package metadata |
| `install.m` | New - Octave/MATLAB install hook |
| `uninstall.m` | New - Octave/MATLAB uninstall hook |
| `+paraxial/init.m` | Modified - added `simulation_scripts_version()` |
| `.github/workflows/release.yml` | New - release workflow |
| `README.md` | Modified - package installation instructions |

## How to test

After merging, create a tag and push:
```
git tag v2.0.0
git push origin v2.0.0
```

GitHub Actions will:
1. Run portable_runner.m (fails workflow if tests fail)
2. Build .tar.gz (Octave) and .mltbx (MATLAB)
3. Attach both to GitHub Release with auto-generated notes

## Verification

- DESCR.ini, install.m, uninstall.m created locally
- simulation_scripts_version() added to +paraxial/init.m
- release.yml created (triggers on tag push)
- README.md updated with package install instructions

## Related

SDD: `openspec/changes/package-distribution-sdd/` (proposal, specs, design, tasks)