### PR TITLE
fix: address repository guardrail review

### DIFF
--- a/openspec/changes/cleanup-modernization-sdd/specs/paraxial-beam-factory/spec.md
+++ b/openspec/changes/cleanup-modernization-sdd/specs/paraxial-beam-factory/spec.md
@@ -24,7 +24,7 @@ Public docs MUST present `BeamFactory.create()` as the stable high-level constru
 
 ### Requirement: Factory beam type registry
 
-BeamFactory SHALL maintain a mapping of beam type names to their canonical class names/locations, supporting: 'gaussian', 'hermite', 'laguerre', 'elegant-hermite', 'elegant-laguerre', 'hankel-hermite', 'hankel-laguerre'. Public docs SHALL list only supported names as default API.
+BeamFactory SHALL maintain a mapping of beam type names to their canonical class names/locations, supporting the default public names returned by `BeamFactory.supportedTypes()`: 'gaussian', 'hermite', 'laguerre', 'elegant_hermite', 'elegant_laguerre', 'hankel', and 'hankel_hermite'. Public docs SHALL list only supported names as default API.
 (Previously: the registry requirement did not require public docs to stay aligned with supported names.)
 
 #### Scenario: Supported beam types

--- a/tests/modern/test_RepositoryGuardrails.m
+++ b/tests/modern/test_RepositoryGuardrails.m
@@ -1,6 +1,7 @@
 % Guardrail: keep repository cleanup and canonical API documentation aligned
 
 repoRoot = fullfile(fileparts(fileparts(fileparts(mfilename('fullpath')))));
+addpath(fullfile(repoRoot, 'ParaxialBeams'));
 
 fprintf('=== Repository Guardrail Tests ===\n\n');
 passed = 0;


### PR DESCRIPTION
## Summary
- Add the `ParaxialBeams/` path inside `test_RepositoryGuardrails.m` so direct execution can resolve `BeamFactory`.
- Align the cleanup-modernization SDD BeamFactory spec with the actual public names returned by `BeamFactory.supportedTypes()`.

## Review comments addressed
- P2 Badge Add ParaxialBeams path before using BeamFactory
- P2 Badge Align BeamFactory type names with actual accepted inputs

## Test Plan
- [x] `octave-cli --no-gui --eval "run('tests/modern/test_RepositoryGuardrails.m')"` — `Repository Guardrails: 7/7 passed`
- [x] `octave-cli --no-gui --eval "run('tests/test_all.m')"` — `Tests Pasados: 33`, `Tests Fallados: 0`

## Notes
No linked issue: this repository has no PR template or issue-reference validation workflow configured.