### PR TITLE
chore: clarify post-v2 modernization policy

### DIFF
--- a/docs/ADDONS_INVENTORY.md
+++ b/docs/ADDONS_INVENTORY.md
@@ -32,11 +32,15 @@ This inventory classifies `ParaxialBeams/Addons/` before any cleanup, migration,
 | `ParaxialBeams/Addons/tight_subplot.m` | `vendored-third-party` | Common external MATLAB helper name; used by legacy plotting scripts. | Confirm origin/license before migration. |
 | `ParaxialBeams/Addons/unwrap_phase.m` | `plotting-only` | Used by legacy plotting/phase visualization scripts. | Keep with visualization helpers. |
 | `ParaxialBeams/Addons/vline.m` | `vendored-third-party` | Common plotting helper name; direct usage not proven in this pass. | Confirm origin/license and usage before removal. |
+| `ParaxialBeams/Addons/getPropagateRay.asv` | `needs-investigation` | MATLAB autosave artifact present at top level; no usage proven in this pass. | Inspect history before deciding whether to remove in a dedicated cleanup change. |
+| `ParaxialBeams/Addons/license.txt` | `vendored-third-party` | Top-level addon license file likely applies to vendored helper assets. | Preserve until vendored origin/license review is complete. |
 
 ## Subdirectories
 
 | Path | Classification | Evidence / Rationale | Follow-up |
 |------|----------------|----------------------|-----------|
+| `ParaxialBeams/Addons/export_fig-master/` | `vendored-third-party` | Vendored MATLAB export helper distribution; top-level directory must be tracked before migration/removal decisions. | Confirm origin/version/license and decide whether to keep, replace, or archive in a dedicated change. |
+| `ParaxialBeams/Addons/panel-2.14/` | `vendored-third-party` | Vendored MATLAB panel layout helper distribution; top-level directory must be tracked before migration/removal decisions. | Confirm origin/version/license and decide whether to keep, replace, or archive in a dedicated change. |
 | `ParaxialBeams/Addons/Plots_Functions/` | `plotting-only` | Contains plotting helpers such as `plotOpticalField`, `plotGaussianParameters`, ray plotting, and circle/square drawing utilities for legacy examples/research figures. | Keep as legacy plotting surface; consider moving to a documented visualization namespace in a dedicated change. |
 
 ## Policy

--- a/docs/ADDONS_INVENTORY.md
+++ b/docs/ADDONS_INVENTORY.md
@@ -1,0 +1,46 @@
+# ParaxialBeams Addons Inventory
+
+This inventory classifies `ParaxialBeams/Addons/` before any cleanup, migration, or removal decision. Cleanup-only work MUST NOT delete addon files solely because usage is unclear.
+
+## Classification Key
+
+| Classification | Meaning |
+|----------------|---------|
+| `runtime-required` | Used by current source/tests or legacy compatibility behavior. |
+| `plotting-only` | Used for figures, visualization, examples, or research scripts. |
+| `vendored-third-party` | Likely external helper; preserve until origin/license is confirmed. |
+| `removable-candidate` | No current evidence of use; requires follow-up SDD before deletion. |
+| `needs-investigation` | Usage/origin unclear; do not remove. |
+
+## Top-level Addons
+
+| Path | Classification | Evidence / Rationale | Follow-up |
+|------|----------------|----------------------|-----------|
+| `ParaxialBeams/Addons/getPropagateCylindricalRays.m` | `runtime-required` | Legacy archive scripts reference the standalone function; modern Hankel implementations retain equivalent static APIs. | Keep until legacy ray APIs are retired. |
+| `ParaxialBeams/Addons/getCylindricalGradient.m` | `runtime-required` | Called by `getPropagateCylindricalRays.m`; `AnalysisUtils` documents matching this legacy logic. | Keep with ray compatibility code. |
+| `ParaxialBeams/Addons/assignCoordinates2CartesianRay.m` | `runtime-required` | Referenced by legacy research/archive scripts and by ray class comments as expected helper shape. | Keep during legacy ray compatibility. |
+| `ParaxialBeams/Addons/assignCoordinates2CylindricalRay.m` | `runtime-required` | Referenced by legacy Laguerre archive scripts for cylindrical ray initialization. | Keep during legacy ray compatibility. |
+| `ParaxialBeams/Addons/copyRay.m` | `runtime-required` | Legacy ray copying helper family used by historical scripts and compatibility APIs. | Investigate consolidation with class methods later. |
+| `ParaxialBeams/Addons/copy2Ray.m` | `needs-investigation` | Part of legacy copy helper family; exact external usage not proven in this pass. | Search broader history before removal. |
+| `ParaxialBeams/Addons/copyElementRay.m` | `needs-investigation` | Part of legacy copy helper family; exact external usage not proven in this pass. | Search broader history before removal. |
+| `ParaxialBeams/Addons/copyElementsOnRay.m` | `needs-investigation` | Part of legacy copy helper family; exact external usage not proven in this pass. | Search broader history before removal. |
+| `ParaxialBeams/Addons/copyRay2ArrayRay.m` | `runtime-required` | Referenced by `OpticalRay` comments as an expected legacy helper. | Keep during ray compatibility. |
+| `ParaxialBeams/Addons/copyArrayRay2Ray.m` | `runtime-required` | Referenced by `OpticalRay` comments as an expected legacy helper. | Keep during ray compatibility. |
+| `ParaxialBeams/Addons/paraxialPropagator.m` | `plotting-only` | Used by legacy archive/research propagation scripts. | Keep with legacy examples until replacement examples exist. |
+| `ParaxialBeams/Addons/propagateOpticalField.m` | `plotting-only` | Used by legacy archive scripts for field propagation loops. | Keep with legacy examples until replacement examples exist. |
+| `ParaxialBeams/Addons/AdvancedColormap.m` | `plotting-only` | Used by legacy archive/generator/research figure scripts. | Preserve for reproducible historical plots. |
+| `ParaxialBeams/Addons/tight_subplot.m` | `vendored-third-party` | Common external MATLAB helper name; used by legacy plotting scripts. | Confirm origin/license before migration. |
+| `ParaxialBeams/Addons/unwrap_phase.m` | `plotting-only` | Used by legacy plotting/phase visualization scripts. | Keep with visualization helpers. |
+| `ParaxialBeams/Addons/vline.m` | `vendored-third-party` | Common plotting helper name; direct usage not proven in this pass. | Confirm origin/license and usage before removal. |
+
+## Subdirectories
+
+| Path | Classification | Evidence / Rationale | Follow-up |
+|------|----------------|----------------------|-----------|
+| `ParaxialBeams/Addons/Plots_Functions/` | `plotting-only` | Contains plotting helpers such as `plotOpticalField`, `plotGaussianParameters`, ray plotting, and circle/square drawing utilities for legacy examples/research figures. | Keep as legacy plotting surface; consider moving to a documented visualization namespace in a dedicated change. |
+
+## Policy
+
+- `removable-candidate` and `needs-investigation` entries MUST remain present until a follow-up SDD change proves they can be removed safely.
+- Runtime and plotting classifications are descriptive, not a promise that the API is modern.
+- Vendored-third-party entries need origin/license review before relocation or redistribution decisions.

--- a/docs/COMPATIBILITY_REDUCTION.md
+++ b/docs/COMPATIBILITY_REDUCTION.md
@@ -1,0 +1,45 @@
+# Compatibility Reduction Plan
+
+This document defines gates for any future reduction of deprecated `src/` behavior. It is intentionally separate from cleanup-only modernization work.
+
+## Current Policy
+
+- `+paraxial/` is the canonical namespace for new code.
+- `BeamFactory.create()` is the preferred high-level construction API.
+- `src/` remains deprecated/transitional during the Strangler Fig migration.
+- Cleanup-only changes MUST NOT remove `src/` paths, classes, adapters, or compatibility tests.
+
+## Required Gates Before Reducing `src/`
+
+1. **Compatibility audit**
+   - List all public classes/functions still reachable through `src/`.
+   - Identify equivalent `+paraxial/` or `BeamFactory` migration paths.
+
+2. **Test coverage**
+   - Keep `tests/legacy_compat/` passing until the removal change explicitly updates the compatibility contract.
+   - Add migration tests that prove canonical APIs cover the supported use cases.
+
+3. **User-facing migration notes**
+   - Document replacement imports/construction calls.
+   - Mark removed aliases or adapters with clear before/after examples.
+
+4. **Dedicated SDD change**
+   - Create a separate OpenSpec change for any removal or behavior reduction.
+   - Include rollback instructions and release-note requirements.
+
+5. **Release coordination**
+   - Update `CHANGELOG.md`.
+   - Avoid bundling compatibility reduction with unrelated cleanup or physics changes.
+
+## Non-Goals for Cleanup Changes
+
+- No deletion of `src/`.
+- No removal of legacy examples solely because they use deprecated paths.
+- No beam physics rewrites.
+- No change to `BeamFactory.supportedTypes()` names without a dedicated API change.
+
+## Candidate Future Work
+
+- Convert remaining direct `src/` example usage to `BeamFactory.create()` where examples are still maintained.
+- Decide whether deprecated constructors should remain as adapters or move to a compatibility package.
+- Split addon plotting helpers from runtime ray helpers after inventory follow-up.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,6 +50,15 @@ Before tagging a release:
 - Keep legacy examples documented as archive/generator/research material.
 - Avoid presenting legacy examples as the default user path.
 
+## Active Follow-up: `post-v2-modernization-next-steps`
+
+The active OpenSpec change `openspec/changes/post-v2-modernization-next-steps/` tracks the next bounded cleanup wave:
+
+- Clarify runner path setup so `+paraxial/` is resolved via the repo root package parent.
+- Keep `src/` paths available only as deprecated/transitional compatibility paths.
+- Inventory `ParaxialBeams/Addons/` before any migration or removal decision.
+- Document compatibility reduction gates before reducing deprecated `src/` behavior.
+
 ## Explicit Non-Goals
 
 - No beam physics rewrites in cleanup-only changes.

--- a/openspec/changes/post-v2-modernization-next-steps/design.md
+++ b/openspec/changes/post-v2-modernization-next-steps/design.md
@@ -1,0 +1,61 @@
+# Design: Post-v2 Modernization Next Steps
+
+## Technical Approach
+
+Implement a second cleanup wave that strengthens executable policy before deleting anything. The runner keeps compatibility paths but names them correctly; guardrails validate stable invariants; docs capture addons and future `src/` reduction decisions.
+
+## Architecture Decisions
+
+| Decision | Choice | Alternatives considered | Rationale |
+|----------|--------|-------------------------|-----------|
+| Runner paths | Add repo root for `+paraxial/`; keep `src/*` as deprecated compatibility | Remove `src/*` immediately | Existing legacy compatibility tests still rely on transitional surfaces. |
+| Guardrails | Extend `test_RepositoryGuardrails.m` with stable text/path checks | Manual review only | The repo already uses structural guardrails for modernization drift. |
+| Addons | Inventory first, no deletion | Delete apparently unused files | Addons may support legacy research/plotting scripts not covered by tests. |
+| Compatibility reduction | Create separate plan document | Fold into cleanup PR | Removing `src/` is a public compatibility decision, not hygiene. |
+
+## Data Flow
+
+```text
+tests/test_all.m
+  └─ portable_runner()
+       ├─ repo root              -> +paraxial package resolution
+       ├─ ParaxialBeams/Addons   -> utilities + legacy helpers
+       ├─ src/*                  -> deprecated compatibility adapters
+       └─ tests/*                -> modern, legacy_compat, edge cases
+
+guardrail test
+  ├─ reads docs and runner text
+  ├─ scans canonical examples
+  └─ checks BeamFactory registry
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `tests/portable_runner.m` | Modify | Add canonical package parent path section; relabel `src/*` as deprecated compatibility. |
+| `tests/modern/test_RepositoryGuardrails.m` | Modify | Assert runner path policy, roadmap ownership, and future `src/` reduction boundaries. |
+| `docs/ROADMAP.md` | Modify | Add active next-wave section and point to this OpenSpec change. |
+| `docs/ADDONS_INVENTORY.md` | Create | Classify addon files/directories with evidence and follow-up action. |
+| `docs/COMPATIBILITY_REDUCTION.md` | Create | Define migration gates before reducing `src/` dependency. |
+| `tests/README.md` | Modify if needed | Prefer `setpaths()` and canonical portable runner commands. |
+
+## Interfaces / Contracts
+
+No public MATLAB API changes. `BeamFactory.supportedTypes()` remains unchanged. `src/` remains available during this change.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Structural | Runner path labels and package parent path | Text assertions in `test_RepositoryGuardrails.m`. |
+| Documentation | Roadmap, addons inventory, compatibility plan exist and use scoped language | Guardrail/manual doc audit. |
+| Integration | Cleanup does not break suite | Run `octave --no-gui --eval "run('tests/test_all.m')"`. |
+
+## Migration / Rollout
+
+No runtime migration. This change prepares future migration by documenting gates before `src/` reduction.
+
+## Open Questions
+
+- [ ] Should addon inventory classify nested plotting functions individually or by subdirectory first?

--- a/openspec/changes/post-v2-modernization-next-steps/proposal.md
+++ b/openspec/changes/post-v2-modernization-next-steps/proposal.md
@@ -1,0 +1,69 @@
+# Proposal: Post-v2 Modernization Next Steps
+
+## Intent
+
+Turn the remaining cleanup roadmap into executable SDD artifacts. The repo already completed a first hygiene pass; this change defines the next bounded wave: runner path clarity, docs/guardrail alignment, addons inventory, and a future compatibility reduction plan without touching beam physics.
+
+## Scope
+
+### In Scope
+- Clarify canonical vs deprecated path setup in `tests/portable_runner.m` and related docs.
+- Add/adjust guardrails for runner path policy and roadmap/doc consistency.
+- Inventory `ParaxialBeams/Addons/` into runtime, plotting, vendored, or removable buckets.
+- Draft a compatibility reduction plan for `src/` without removing `src/`.
+
+### Out of Scope
+- Rewriting optical formulas, propagation algorithms, or numerical behavior.
+- Deleting `src/`, legacy examples, or addons without a dedicated follow-up change.
+- Building release/package artifacts.
+- Changing public `BeamFactory.supportedTypes()` names.
+
+## Capabilities
+
+### New Capabilities
+- `runner-path-policy`: Canonical and deprecated MATLAB/Octave paths are explicit and testable.
+- `legacy-addons-inventory`: Addons are classified before removal or migration decisions.
+- `modernization-roadmap-governance`: Active roadmap, SDD changes, and docs remain aligned.
+
+### Modified Capabilities
+- None.
+
+## Approach
+
+Use a documentation-and-guardrail-first cleanup. Update runner setup comments/structure, encode stable invariants in guardrail tests, inventory addons without deletion, and document future migration gates.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `tests/portable_runner.m` | Modified | Separate canonical, deprecated, utility, and legacy paths. |
+| `tests/modern/test_RepositoryGuardrails.m` | Modified | Add runner/path and roadmap consistency assertions. |
+| `docs/ROADMAP.md` | Modified | Track next-wave cleanup and compatibility reduction gates. |
+| `docs/ADDONS_INVENTORY.md` | Created | Classify addon files with rationale and follow-up action. |
+| `docs/COMPATIBILITY_REDUCTION.md` | Created | Define preconditions for reducing deprecated `src/` usage. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Path cleanup breaks legacy tests | Medium | Preserve `src/` paths but label them deprecated compatibility. |
+| Addons classification is incomplete | Medium | Inventory only; no deletions in this change. |
+| Guardrails become brittle | Medium | Assert stable policy text and paths, not prose formatting. |
+
+## Rollback Plan
+
+Revert the docs/guardrail/runner commits. Since no runtime formulas or deletions are included, rollback restores previous path setup and documentation only.
+
+## Dependencies
+
+- Existing roadmap: `docs/ROADMAP.md`.
+- Existing guardrails: `tests/modern/test_RepositoryGuardrails.m`.
+- Canonical test runner: `tests/portable_runner.m`.
+
+## Success Criteria
+
+- [ ] Runner setup explicitly adds repo root for `+paraxial/` and labels `src/` as deprecated compatibility.
+- [ ] Guardrails verify runner/docs do not regress.
+- [ ] Addons inventory exists with every top-level addon classified.
+- [ ] Compatibility reduction plan exists and does not remove `src/`.
+- [ ] Portable Octave runner passes after implementation.

--- a/openspec/changes/post-v2-modernization-next-steps/specs/legacy-addons-inventory/spec.md
+++ b/openspec/changes/post-v2-modernization-next-steps/specs/legacy-addons-inventory/spec.md
@@ -1,0 +1,40 @@
+# Legacy Addons Inventory Specification
+
+## Purpose
+
+Ensure `ParaxialBeams/Addons/` is classified before any migration, deletion, or vendored-code decision.
+
+## Requirements
+
+### Requirement: Addon Classification
+
+Every top-level addon file and addon subdirectory MUST be classified before cleanup decisions are made.
+
+#### Scenario: Inventory is created
+
+- GIVEN files exist under `ParaxialBeams/Addons/`
+- WHEN the addons inventory is produced
+- THEN each top-level `.m` file and subdirectory MUST appear in `docs/ADDONS_INVENTORY.md`
+- AND each entry MUST have exactly one classification.
+
+### Requirement: Supported Classifications
+
+Addon entries MUST use one of: runtime-required, plotting-only, vendored-third-party, removable-candidate, or needs-investigation.
+
+#### Scenario: Unknown usage
+
+- GIVEN addon usage cannot be proven from tests, examples, or source references
+- WHEN the inventory is written
+- THEN the entry MUST be marked `needs-investigation`
+- AND it MUST NOT be deleted in this change.
+
+### Requirement: No Deletion Without Follow-up SDD
+
+This change MUST NOT delete addon files solely because they appear unused.
+
+#### Scenario: Removable candidate found
+
+- GIVEN an addon is classified as `removable-candidate`
+- WHEN implementation completes
+- THEN the file MUST remain present
+- AND a follow-up SDD change SHOULD be referenced for removal.

--- a/openspec/changes/post-v2-modernization-next-steps/specs/modernization-roadmap-governance/spec.md
+++ b/openspec/changes/post-v2-modernization-next-steps/specs/modernization-roadmap-governance/spec.md
@@ -1,0 +1,40 @@
+# Modernization Roadmap Governance Specification
+
+## Purpose
+
+Keep active modernization work discoverable, scoped, and aligned with executable guardrails.
+
+## Requirements
+
+### Requirement: Roadmap Owns Active Next Steps
+
+`docs/ROADMAP.md` MUST identify active cleanup phases and SHOULD point to current SDD changes for detailed execution.
+
+#### Scenario: New modernization SDD exists
+
+- GIVEN an active OpenSpec change exists for modernization cleanup
+- WHEN `docs/ROADMAP.md` is reviewed
+- THEN it SHOULD reference the change or its tracked work area
+- AND root `plan.md` MUST NOT be presented as the active roadmap.
+
+### Requirement: Compatibility Reduction Is Planned Separately
+
+Reducing or removing deprecated `src/` behavior MUST require a dedicated plan with preconditions.
+
+#### Scenario: `src/` cleanup is discussed
+
+- GIVEN docs mention future `src/` reduction
+- WHEN the work is scoped
+- THEN docs MUST state that `src/` removal is out of scope for cleanup-only changes
+- AND preconditions MUST include compatibility tests and user-facing migration notes.
+
+### Requirement: Guardrails Track Stable Invariants
+
+Guardrail tests SHOULD verify stable architecture invariants, not exact prose formatting.
+
+#### Scenario: Docs wording changes
+
+- GIVEN docs are edited without changing policy
+- WHEN guardrail tests run
+- THEN tests SHOULD pass if canonical CI, canonical API, and deprecated-surface policy remain present
+- AND tests SHOULD fail if those policies disappear.

--- a/openspec/changes/post-v2-modernization-next-steps/specs/runner-path-policy/spec.md
+++ b/openspec/changes/post-v2-modernization-next-steps/specs/runner-path-policy/spec.md
@@ -1,0 +1,40 @@
+# Runner Path Policy Specification
+
+## Purpose
+
+Define how development and test runners expose canonical, deprecated, utility, and legacy paths during the Strangler Fig migration.
+
+## Requirements
+
+### Requirement: Canonical Package Parent Path
+
+The test runner MUST add the repository root, not internal `+package` folders, so `+paraxial/` resolves through MATLAB/Octave package semantics.
+
+#### Scenario: Portable runner initializes canonical package
+
+- GIVEN `+paraxial/` exists at repo root
+- WHEN `tests/portable_runner.m` initializes paths
+- THEN repo root MUST be added to the path
+- AND internal `+paraxial` subfolders MUST NOT be added directly.
+
+### Requirement: Deprecated Paths Are Explicit
+
+Deprecated `src/` paths MAY remain in the runner for compatibility, but they MUST be labeled as deprecated/transitional compatibility paths.
+
+#### Scenario: Runner keeps compatibility paths
+
+- GIVEN legacy compatibility tests still require `src/` adapters
+- WHEN the runner adds `src/beams` or related folders
+- THEN comments MUST identify them as deprecated compatibility paths
+- AND comments MUST NOT call them the modern library paths.
+
+### Requirement: setpaths Remains Preferred Dev Setup
+
+Developer-facing docs SHOULD prefer `setpaths()` for local setup and direct test invocation.
+
+#### Scenario: Docs describe manual setup
+
+- GIVEN docs show local MATLAB/Octave path setup
+- WHEN users follow the recommended setup
+- THEN `setpaths()` SHOULD be the first recommendation
+- AND package parent path semantics SHOULD be preserved.

--- a/openspec/changes/post-v2-modernization-next-steps/tasks.md
+++ b/openspec/changes/post-v2-modernization-next-steps/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: Post-v2 Modernization Next Steps
+
+## Phase 1: Runner Path Policy
+
+- [x] 1.1 Update `tests/portable_runner.m` to add repo root under a canonical `+paraxial/` package section.
+- [x] 1.2 Relabel `src/*` path additions in `tests/portable_runner.m` as deprecated/transitional compatibility paths.
+- [x] 1.3 Confirm `ParaxialBeams/` and `ParaxialBeams/Addons/` remain utility/addon sections, not canonical package paths.
+
+## Phase 2: Guardrails
+
+- [x] 2.1 Extend `tests/modern/test_RepositoryGuardrails.m` to assert `portable_runner.m` does not call `src/*` “modern library paths”.
+- [x] 2.2 Add a guardrail that `portable_runner.m` or `setpaths.m` preserves repo-root package parent semantics for `+paraxial/`.
+- [x] 2.3 Add roadmap guardrail checks for `docs/ROADMAP.md` and historical root `plan.md` wording.
+
+## Phase 3: Addons Inventory
+
+- [x] 3.1 Create `docs/ADDONS_INVENTORY.md` with classifications for top-level `ParaxialBeams/Addons/*.m` files.
+- [x] 3.2 Classify `ParaxialBeams/Addons/Plots_Functions/` as a subdirectory entry with evidence and follow-up action.
+- [x] 3.3 Mark uncertain entries as `needs-investigation`; do not delete addon files in this change.
+
+## Phase 4: Compatibility Reduction Planning
+
+- [x] 4.1 Create `docs/COMPATIBILITY_REDUCTION.md` defining gates before reducing `src/` usage or availability.
+- [x] 4.2 Update `docs/ROADMAP.md` to reference runner cleanup, addons inventory, and compatibility reduction as active next steps.
+- [x] 4.3 Update `tests/README.md` if it conflicts with `setpaths()` or portable runner path policy.
+
+## Phase 5: Verification
+
+- [x] 5.1 Run `octave --no-gui --eval "run('tests/test_all.m')"` and record result. Passed with 33 passed, 0 failed using Octave 11.1.0 absolute path.
+- [x] 5.2 Run `octave-cli --no-gui --eval "run('tests/modern/test_RepositoryGuardrails.m')"` and record result. Passed with 12/12 guardrails using Octave 11.1.0 absolute path.
+- [x] 5.3 Confirm `git diff` shows no beam physics changes under `+paraxial/+beams/`, `src/beams/`, `src/parameters/`, or `src/computation/`.

--- a/openspec/changes/post-v2-modernization-next-steps/verify-report.md
+++ b/openspec/changes/post-v2-modernization-next-steps/verify-report.md
@@ -36,7 +36,7 @@ Command:
 C:\Users\uidn7961\AppData\Local\Programs\GNU Octave\Octave-11.1.0\mingw64\bin\octave-cli.exe --no-gui --eval "run('tests/modern/test_RepositoryGuardrails.m')"
 
 Result:
-=== Repository Guardrails: 12/12 passed ===
+=== Repository Guardrails: 13/13 passed ===
 ```
 
 **Coverage**: Not available — no coverage tool is configured for this repository.
@@ -45,15 +45,15 @@ Result:
 
 | Requirement | Scenario | Evidence | Result |
 |-------------|----------|----------|--------|
-| Canonical Package Parent Path | Portable runner initializes canonical package | `test_RepositoryGuardrails.m` checks canonical package section and `addpath(repoRoot)`; guardrails 12/12 passed. | ✅ COMPLIANT |
-| Deprecated Paths Are Explicit | Runner keeps compatibility paths | `test_RepositoryGuardrails.m` checks `Deprecated compatibility paths (src/)`; guardrails 12/12 passed. | ✅ COMPLIANT |
+| Canonical Package Parent Path | Portable runner initializes canonical package | `test_RepositoryGuardrails.m` checks canonical package section and `addpath(repoRoot)`; guardrails 13/13 passed. | ✅ COMPLIANT |
+| Deprecated Paths Are Explicit | Runner keeps compatibility paths | `test_RepositoryGuardrails.m` checks `Deprecated compatibility paths (src/)`; guardrails 13/13 passed. | ✅ COMPLIANT |
 | setpaths Remains Preferred Dev Setup | Docs describe manual setup | `tests/README.md` documents `setpaths()` and package-parent semantics; full suite passed. | ✅ COMPLIANT |
-| Addon Classification | Inventory is created | `docs/ADDONS_INVENTORY.md` exists and guardrail validates required classifications; guardrails 12/12 passed. | ✅ COMPLIANT |
+| Addon Classification | Inventory is created | `docs/ADDONS_INVENTORY.md` exists and guardrail validates every top-level addon entry; guardrails 13/13 passed. | ✅ COMPLIANT |
 | Supported Classifications | Unknown usage | Inventory includes `needs-investigation` entries and no addon deletion occurred. | ✅ COMPLIANT |
 | No Deletion Without Follow-up SDD | Removable candidate found | Inventory policy requires follow-up SDD before deletion; no addon files removed. | ✅ COMPLIANT |
-| Roadmap Owns Active Next Steps | New modernization SDD exists | `docs/ROADMAP.md` references `post-v2-modernization-next-steps`; guardrails 12/12 passed. | ✅ COMPLIANT |
-| Compatibility Reduction Is Planned Separately | `src/` cleanup is discussed | `docs/COMPATIBILITY_REDUCTION.md` defines gates and cleanup non-goals; guardrails 12/12 passed. | ✅ COMPLIANT |
-| Guardrails Track Stable Invariants | Docs wording changes | Structural guardrails validate stable policy text; guardrails 12/12 passed. | ✅ COMPLIANT |
+| Roadmap Owns Active Next Steps | New modernization SDD exists | `docs/ROADMAP.md` references `post-v2-modernization-next-steps`; guardrails 13/13 passed. | ✅ COMPLIANT |
+| Compatibility Reduction Is Planned Separately | `src/` cleanup is discussed | `docs/COMPATIBILITY_REDUCTION.md` defines gates and cleanup non-goals; guardrails 13/13 passed. | ✅ COMPLIANT |
+| Guardrails Track Stable Invariants | Docs wording changes | Structural guardrails validate stable policy text; guardrails 13/13 passed. | ✅ COMPLIANT |
 
 **Compliance summary**: 9/9 scenarios compliant.
 

--- a/openspec/changes/post-v2-modernization-next-steps/verify-report.md
+++ b/openspec/changes/post-v2-modernization-next-steps/verify-report.md
@@ -1,0 +1,89 @@
+# Verification Report: Post-v2 Modernization Next Steps
+
+**Change**: `post-v2-modernization-next-steps`  
+**Mode**: Standard  
+**Date**: 2026-04-30
+
+## Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 15 |
+| Tasks complete | 15 |
+| Tasks incomplete | 0 |
+
+## Build & Tests Execution
+
+**Build**: Not applicable — MATLAB/Octave project has no configured build/typecheck command for this cleanup change.
+
+**Tests**: Passed.
+
+```text
+Command:
+C:\Users\uidn7961\AppData\Local\Programs\GNU Octave\Octave-11.1.0\mingw64\bin\octave.exe --no-gui --eval "run('tests/test_all.m')"
+
+Result:
+Tests Pasados: 33
+Tests Fallados: 0
+ESTADO: ÉXITO
+=== ÉXITO: Todos los tests pasaron ===
+```
+
+**Focused guardrail test**: Passed.
+
+```text
+Command:
+C:\Users\uidn7961\AppData\Local\Programs\GNU Octave\Octave-11.1.0\mingw64\bin\octave-cli.exe --no-gui --eval "run('tests/modern/test_RepositoryGuardrails.m')"
+
+Result:
+=== Repository Guardrails: 12/12 passed ===
+```
+
+**Coverage**: Not available — no coverage tool is configured for this repository.
+
+## Spec Compliance Matrix
+
+| Requirement | Scenario | Evidence | Result |
+|-------------|----------|----------|--------|
+| Canonical Package Parent Path | Portable runner initializes canonical package | `test_RepositoryGuardrails.m` checks canonical package section and `addpath(repoRoot)`; guardrails 12/12 passed. | ✅ COMPLIANT |
+| Deprecated Paths Are Explicit | Runner keeps compatibility paths | `test_RepositoryGuardrails.m` checks `Deprecated compatibility paths (src/)`; guardrails 12/12 passed. | ✅ COMPLIANT |
+| setpaths Remains Preferred Dev Setup | Docs describe manual setup | `tests/README.md` documents `setpaths()` and package-parent semantics; full suite passed. | ✅ COMPLIANT |
+| Addon Classification | Inventory is created | `docs/ADDONS_INVENTORY.md` exists and guardrail validates required classifications; guardrails 12/12 passed. | ✅ COMPLIANT |
+| Supported Classifications | Unknown usage | Inventory includes `needs-investigation` entries and no addon deletion occurred. | ✅ COMPLIANT |
+| No Deletion Without Follow-up SDD | Removable candidate found | Inventory policy requires follow-up SDD before deletion; no addon files removed. | ✅ COMPLIANT |
+| Roadmap Owns Active Next Steps | New modernization SDD exists | `docs/ROADMAP.md` references `post-v2-modernization-next-steps`; guardrails 12/12 passed. | ✅ COMPLIANT |
+| Compatibility Reduction Is Planned Separately | `src/` cleanup is discussed | `docs/COMPATIBILITY_REDUCTION.md` defines gates and cleanup non-goals; guardrails 12/12 passed. | ✅ COMPLIANT |
+| Guardrails Track Stable Invariants | Docs wording changes | Structural guardrails validate stable policy text; guardrails 12/12 passed. | ✅ COMPLIANT |
+
+**Compliance summary**: 9/9 scenarios compliant.
+
+## Correctness — Structural Evidence
+
+| Requirement | Status | Notes |
+|-------------|--------|-------|
+| Runner path policy | ✅ Implemented | `tests/portable_runner.m` adds repo root and labels `src/` paths as deprecated compatibility. |
+| Addons inventory | ✅ Implemented | Top-level addons and `Plots_Functions/` are classified without deletion. |
+| Roadmap governance | ✅ Implemented | Roadmap points to the active OpenSpec change and keeps `src/` removal out of cleanup scope. |
+
+## Coherence — Design
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Runner paths | ✅ Yes | Repo root added; `src/*` retained as compatibility paths. |
+| Guardrails | ✅ Yes | `test_RepositoryGuardrails.m` extended with runner, roadmap, addons, and compatibility checks. |
+| Addons | ✅ Yes | Inventory-first approach; no deletion performed. |
+| Compatibility reduction | ✅ Yes | Dedicated compatibility reduction plan created. |
+
+## Issues Found
+
+**CRITICAL**: None.
+
+**WARNING**: Full suite emits expected deprecation warnings from transitional `src/` adapters.
+
+**SUGGESTION**: Future SDD may itemize nested plotting helpers individually if finer-grained addon ownership is needed.
+
+## Verdict
+
+PASS
+
+The implementation satisfies the SDD specs and passed the focused guardrail test plus the full portable Octave suite.

--- a/setpaths.m
+++ b/setpaths.m
@@ -13,7 +13,7 @@ function setpaths()
     %   ...
     %
     % Modern package (+paraxial/):
-    %   addpath('+paraxial');  % enables 'import paraxial.*'
+    %   addpath(repoRoot);  % package parent enables 'import paraxial.*'
     %   import paraxial.beams.GaussianBeam
     %
     % Utilities (ParaxialBeams/):

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,6 +6,8 @@ This directory contains tests for the ParaxialBeams simulation library.
 
 `tests/portable_runner.m` is the canonical non-interactive runner. `tests/test_all.m` is the portable wrapper used by humans and CI.
 
+For local development setup before direct script invocation, run `setpaths()` from the repository root. This preserves MATLAB/Octave package semantics by adding the repo root as the parent of `+paraxial/` instead of adding internal `+package` folders directly.
+
 ```bash
 octave --no-gui --eval "run('tests/test_all.m')"
 ```
@@ -97,7 +99,7 @@ Tests follow consistent patterns:
 ## Portable Runner
 
 `tests/portable_runner.m` is the canonical non-interactive runner used by `tests/test_all.m`.
-It executes both modern and legacy compatibility suites.
+It executes canonical tests and legacy compatibility suites. The runner adds the repository root for `+paraxial/` package resolution and keeps `src/` paths only as deprecated/transitional compatibility paths.
 
 For a faster legacy-only check during migration work:
 

--- a/tests/modern/test_RepositoryGuardrails.m
+++ b/tests/modern/test_RepositoryGuardrails.m
@@ -44,6 +44,7 @@ addonsInventoryPath = fullfile(repoRoot, 'docs', 'ADDONS_INVENTORY.md');
 compatReductionPath = fullfile(repoRoot, 'docs', 'COMPATIBILITY_REDUCTION.md');
 planPath = fullfile(repoRoot, 'plan.md');
 portableRunnerPath = fullfile(repoRoot, 'tests', 'portable_runner.m');
+addonsDir = fullfile(repoRoot, 'ParaxialBeams', 'Addons');
 if exist(readmePath, 'file')
     readmeContent = fileread(readmePath);
 else
@@ -143,6 +144,35 @@ if ~isempty(strfind(addonsInventoryContent, 'runtime-required')) && ...
     passed = passed + 1;
 else
     fprintf('  FAIL: addons inventory is missing required classifications\n');
+    failed = failed + 1;
+end
+
+addonEntries = dir(addonsDir);
+missingAddonEntries = {};
+for i = 1:numel(addonEntries)
+    entryName = addonEntries(i).name;
+    if strcmp(entryName, '.') || strcmp(entryName, '..')
+        continue;
+    end
+
+    inventoryEntry = ['ParaxialBeams/Addons/' entryName];
+    if addonEntries(i).isdir
+        inventoryEntry = [inventoryEntry '/'];
+    end
+
+    if isempty(strfind(addonsInventoryContent, inventoryEntry))
+        missingAddonEntries{end+1} = inventoryEntry; %#ok<AGROW>
+    end
+end
+
+if isempty(missingAddonEntries)
+    fprintf('  PASS: addons inventory lists every top-level addon entry\n');
+    passed = passed + 1;
+else
+    fprintf('  FAIL: addons inventory is missing top-level addon entries\n');
+    for i = 1:numel(missingAddonEntries)
+        fprintf('    - %s\n', missingAddonEntries{i});
+    end
     failed = failed + 1;
 end
 

--- a/tests/modern/test_RepositoryGuardrails.m
+++ b/tests/modern/test_RepositoryGuardrails.m
@@ -39,6 +39,11 @@ end
 % -------------------------------------------------------------------------
 readmePath = fullfile(repoRoot, 'README.md');
 registryPath = fullfile(repoRoot, '.atl', 'skill-registry.md');
+roadmapPath = fullfile(repoRoot, 'docs', 'ROADMAP.md');
+addonsInventoryPath = fullfile(repoRoot, 'docs', 'ADDONS_INVENTORY.md');
+compatReductionPath = fullfile(repoRoot, 'docs', 'COMPATIBILITY_REDUCTION.md');
+planPath = fullfile(repoRoot, 'plan.md');
+portableRunnerPath = fullfile(repoRoot, 'tests', 'portable_runner.m');
 if exist(readmePath, 'file')
     readmeContent = fileread(readmePath);
 else
@@ -48,6 +53,31 @@ if exist(registryPath, 'file')
     registryContent = fileread(registryPath);
 else
     registryContent = '';
+end
+if exist(roadmapPath, 'file')
+    roadmapContent = fileread(roadmapPath);
+else
+    roadmapContent = '';
+end
+if exist(addonsInventoryPath, 'file')
+    addonsInventoryContent = fileread(addonsInventoryPath);
+else
+    addonsInventoryContent = '';
+end
+if exist(compatReductionPath, 'file')
+    compatReductionContent = fileread(compatReductionPath);
+else
+    compatReductionContent = '';
+end
+if exist(planPath, 'file')
+    planContent = fileread(planPath);
+else
+    planContent = '';
+end
+if exist(portableRunnerPath, 'file')
+    portableRunnerContent = fileread(portableRunnerPath);
+else
+    portableRunnerContent = '';
 end
 
 if ~isempty(strfind(readmeContent, 'GitHub Actions is the canonical CI system'))
@@ -71,6 +101,58 @@ if ~isempty(strfind(registryContent, 'Octave 11.1.0+')) && isempty(strfind(regis
     passed = passed + 1;
 else
     fprintf('  FAIL: skill registry Octave baseline is stale or inconsistent\n');
+    failed = failed + 1;
+end
+
+% -------------------------------------------------------------------------
+% Runner path policy and roadmap governance
+% -------------------------------------------------------------------------
+if ~isempty(strfind(portableRunnerContent, 'Canonical package namespace')) && ...
+   ~isempty(strfind(portableRunnerContent, "addpath(repoRoot)")) && ...
+   isempty(strfind(portableRunnerContent, 'Add modern library paths (src/)'))
+    fprintf('  PASS: portable runner documents canonical package parent path policy\n');
+    passed = passed + 1;
+else
+    fprintf('  FAIL: portable runner path policy is stale or ambiguous\n');
+    failed = failed + 1;
+end
+
+if ~isempty(strfind(portableRunnerContent, 'Deprecated compatibility paths (src/)'))
+    fprintf('  PASS: portable runner labels src/ paths as deprecated compatibility\n');
+    passed = passed + 1;
+else
+    fprintf('  FAIL: portable runner does not label src/ paths as deprecated compatibility\n');
+    failed = failed + 1;
+end
+
+if ~isempty(strfind(roadmapContent, 'post-v2-modernization-next-steps')) && ...
+   ~isempty(strfind(roadmapContent, 'No removal of `src/` without a dedicated migration SDD')) && ...
+   ~isempty(strfind(planContent, 'Historical'))
+    fprintf('  PASS: roadmap owns active modernization next steps\n');
+    passed = passed + 1;
+else
+    fprintf('  FAIL: roadmap governance for active modernization next steps is incomplete\n');
+    failed = failed + 1;
+end
+
+if ~isempty(strfind(addonsInventoryContent, 'runtime-required')) && ...
+   ~isempty(strfind(addonsInventoryContent, 'plotting-only')) && ...
+   ~isempty(strfind(addonsInventoryContent, 'needs-investigation')) && ...
+   ~isempty(strfind(addonsInventoryContent, 'Plots_Functions'))
+    fprintf('  PASS: addons inventory classifies legacy addon surfaces\n');
+    passed = passed + 1;
+else
+    fprintf('  FAIL: addons inventory is missing required classifications\n');
+    failed = failed + 1;
+end
+
+if ~isempty(strfind(compatReductionContent, 'Cleanup-only changes MUST NOT remove `src/`')) && ...
+   ~isempty(strfind(compatReductionContent, 'tests/legacy_compat/')) && ...
+   ~isempty(strfind(compatReductionContent, 'Dedicated SDD change'))
+    fprintf('  PASS: compatibility reduction plan defines src/ migration gates\n');
+    passed = passed + 1;
+else
+    fprintf('  FAIL: compatibility reduction plan is missing src/ migration gates\n');
     failed = failed + 1;
 end
 

--- a/tests/portable_runner.m
+++ b/tests/portable_runner.m
@@ -8,7 +8,15 @@ function totalFailed = portable_runner()
     testDir = fileparts(mfilename('fullpath'));
     repoRoot = fullfile(testDir, '..');
     
-    % Add modern library paths (src/)
+    % Canonical package namespace (+paraxial/)
+    % MATLAB/Octave packages are resolved by adding the parent directory.
+    % Do not add internal +package folders directly.
+    addpath(repoRoot);
+
+    % Deprecated compatibility paths (src/)
+    % Keep these during the Strangler Fig migration so legacy adapters and
+    % compatibility tests remain executable. New code should prefer +paraxial/
+    % or BeamFactory.create().
     addpath(fullfile(repoRoot, 'src', 'beams'));
     addpath(fullfile(repoRoot, 'src', 'parameters'));
     addpath(fullfile(repoRoot, 'src', 'computation'));
@@ -16,7 +24,7 @@ function totalFailed = portable_runner()
     addpath(fullfile(repoRoot, 'src', 'propagation', 'rays'));
     addpath(fullfile(repoRoot, 'src', 'visualization'));
     
-    % Add utilities (ParaxialBeams/)
+    % Add utilities and legacy addons (ParaxialBeams/)
     addpath(fullfile(repoRoot, 'ParaxialBeams'));
     addpath(fullfile(repoRoot, 'ParaxialBeams', 'Addons'));
     


### PR DESCRIPTION
Closes #46

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary
- Clarifies `+paraxial/` package-parent path setup and labels `src/` paths as deprecated compatibility.
- Adds guardrails for runner policy, roadmap ownership, addons inventory, and compatibility reduction gates.
- Captures the follow-up modernization work in OpenSpec/SDD artifacts with verification evidence.

## Changes
| File | Change |
|------|--------|
| `tests/portable_runner.m` | Adds repo root for canonical package resolution and relabels `src/*` compatibility paths. |
| `tests/modern/test_RepositoryGuardrails.m` | Adds structural guardrails for runner, roadmap, addons, and compatibility planning. |
| `docs/ADDONS_INVENTORY.md` | Classifies legacy addon surfaces before removal decisions. |
| `docs/COMPATIBILITY_REDUCTION.md` | Defines gates before reducing deprecated `src/` behavior. |
| `docs/ROADMAP.md` | References the active modernization follow-up SDD. |
| `openspec/changes/post-v2-modernization-next-steps/` | Adds proposal, specs, design, tasks, and verify report. |

## Test Plan
- [x] `octave-cli --no-gui --eval "run('tests/modern/test_RepositoryGuardrails.m')"` ΓåÆ `13/13 passed`
- [x] `octave --no-gui --eval "run('tests/test_all.m')"` ΓåÆ `Tests Pasados: 33`, `Tests Fallados: 0`, `ESTADO: ├ëXITO`
- [x] Confirmed no beam physics diffs under `+paraxial/+beams/`, `src/beams/`, `src/parameters/`, or `src/computation/`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (not applicable: no shell scripts modified)
- [x] Skills tested in at least one agent (not applicable: no agent skill code modified)
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
