### PR TITLE
fix(tests): suppress deprecated adapter warning storm

### DIFF
--- a/tests/modern/test_RepositoryGuardrails.m
+++ b/tests/modern/test_RepositoryGuardrails.m
@@ -132,8 +132,10 @@ else
     failed = failed + 1;
 end
 
+% onCleanup guarantees restoration on ANY exit (normal, error, interrupt).
+% The cleanup anonymous function holds the restoration call inline.
 if ~isempty(strfind(portableRunnerContent, "warning('off', 'BeamFactory:deprecated')")) && ...
-   ~isempty(strfind(portableRunnerContent, "warning(previousDeprecatedWarningState.state, 'BeamFactory:deprecated')"))
+   ~isempty(strfind(portableRunnerContent, 'cleanupObj = onCleanup(@() warning(previousDeprecatedWarningState.state, '))
     fprintf('  PASS: portable runner suppresses expected deprecated-adapter warning storm\n');
     passed = passed + 1;
 else

--- a/tests/modern/test_RepositoryGuardrails.m
+++ b/tests/modern/test_RepositoryGuardrails.m
@@ -132,6 +132,15 @@ else
     failed = failed + 1;
 end
 
+if ~isempty(strfind(portableRunnerContent, "warning('off', 'BeamFactory:deprecated')")) && ...
+   ~isempty(strfind(portableRunnerContent, "warning(previousDeprecatedWarningState.state, 'BeamFactory:deprecated')"))
+    fprintf('  PASS: portable runner suppresses expected deprecated-adapter warning storm\n');
+    passed = passed + 1;
+else
+    fprintf('  FAIL: portable runner does not suppress/restore expected deprecated-adapter warnings\n');
+    failed = failed + 1;
+end
+
 staleWavefrontRoot = ~isempty(strfind(wavefrontTestContent, "repoRoot = fullfile(testDir, '..');"));
 addsProjectPaths = ~isempty(strfind(wavefrontTestContent, "addpath(fullfile(repoRoot, 'src'")) || ...
                    ~isempty(strfind(wavefrontTestContent, "addpath(fullfile(repoRoot, 'ParaxialBeams'"));

--- a/tests/portable_runner.m
+++ b/tests/portable_runner.m
@@ -40,6 +40,13 @@ function totalFailed = portable_runner()
     % Hankele* aliases were removed; legacy_compat tests assert post-removal
     % migration behavior when this flag is enabled.
     setenv('LEGACY_ALIAS_REMOVAL_MODE', '1');
+
+    % Expected deprecation warnings from transitional src/ adapters can occur
+    % in tight numerical loops (notably Hankel ray tracing). Suppress only
+    % this known warning ID for the portable suite, then restore it before
+    % returning so normal interactive sessions still surface deprecations.
+    previousDeprecatedWarningState = warning('query', 'BeamFactory:deprecated');
+    warning('off', 'BeamFactory:deprecated');
     
     % Canonical list of tests to run (from tests/modern/)
     testFiles = {
@@ -122,6 +129,8 @@ function totalFailed = portable_runner()
         fprintf('ESTADO: ÉXITO\n');
         % exit(0);
     end
+
+    warning(previousDeprecatedWarningState.state, 'BeamFactory:deprecated');
 end
 
 function [passed, failed] = run_class_test(className)

--- a/tests/portable_runner.m
+++ b/tests/portable_runner.m
@@ -45,8 +45,12 @@ function totalFailed = portable_runner()
     % in tight numerical loops (notably Hankel ray tracing). Suppress only
     % this known warning ID for the portable suite, then restore it before
     % returning so normal interactive sessions still surface deprecations.
+    % Use onCleanup to guarantee restoration on ANY exit path (normal, error,
+    % or keyboard interrupt). Without it, a early termination would leave
+    % the deprecation warning permanently suppressed in the session.
     previousDeprecatedWarningState = warning('query', 'BeamFactory:deprecated');
     warning('off', 'BeamFactory:deprecated');
+    cleanupObj = onCleanup(@() warning(previousDeprecatedWarningState.state, 'BeamFactory:deprecated'));
     
     % Canonical list of tests to run (from tests/modern/)
     testFiles = {
@@ -125,12 +129,10 @@ function totalFailed = portable_runner()
     if totalFailed > 0
         fprintf('ESTADO: FALLO\n');
         % exit(1); % Uncomment if running from CLI only
-    else
+else
         fprintf('ESTADO: ÉXITO\n');
         % exit(0);
     end
-
-    warning(previousDeprecatedWarningState.state, 'BeamFactory:deprecated');
 end
 
 function [passed, failed] = run_class_test(className)


### PR DESCRIPTION
Closes #50

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Suppresses only the expected `BeamFactory:deprecated` warning ID during the portable test suite.
- Restores the previous warning state after the suite completes so interactive deprecation warnings remain visible.
- Adds a repository guardrail to prevent regression of the suppression/restoration behavior.

## Changes
| File | Change |
|------|--------|
| `tests/portable_runner.m` | Suppress and restore expected deprecated-adapter warning during portable suite execution. |
| `tests/modern/test_RepositoryGuardrails.m` | Add guardrail ensuring warning suppression/restoration remains present. |

## Test Plan
- [x] `octave-cli --no-gui --eval "run('tests/modern/test_RepositoryGuardrails.m')"` — 15/15 guardrails passed
- [x] `octave --no-gui --eval "run('tests/test_all.m')"` — Tests Pasados: 33, Tests Fallados: 0, ESTADO: ÉXITO
- [x] Shellcheck not applicable — no shell scripts modified

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts / marked not applicable
- [x] Skills tested in at least one agent / not applicable for MATLAB test-runner change
- [x] Docs updated if behavior changed / not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
