### PR TITLE
fix: handle matrix z in Hankel beam field calculations

### DIFF
--- a/+paraxial/+beams/HankelHermite.m
+++ b/+paraxial/+beams/HankelHermite.m
@@ -158,15 +158,22 @@ classdef HankelHermite < ParaxialBeam
             m      = obj.m;
             ht     = obj.HankelType;
 
-            w   = w0 * sqrt(1 + (z/zr)^2);
-            Rc  = z  * (1 + (zr/z)^2);
-            if z == 0, Rc = Inf; end
-            psi = atan2(z, zr);
+            % Ensure z is scalar (RayBundle may pass matrix z, but field
+            % is computed at a single z-plane)
+            z_scalar = z(1);
+            if ~isscalar(z_scalar)
+                z_scalar = z(1);
+            end
+
+            w   = w0 * sqrt(1 + (z_scalar/zr)^2);
+            Rc  = z_scalar * (1 + (zr/z_scalar)^2);
+            if z_scalar == 0, Rc = Inf; end
+            psi = atan2(z_scalar, zr);
 
             % Gaussian carrier field u_0(r,z)
             r          = sqrt(X.^2 + Y.^2);
             amplitude  = (w0 ./ w) .* exp(-r.^2 ./ w.^2);
-            phase_z    = -1i * k * z;
+            phase_z    = -1i * k * z_scalar;
             phase_curv = 1i * k * r.^2 ./ (2 * Rc);
             phase_curv(isinf(Rc)) = 0;
             phase_gouy = -1i * psi;
@@ -179,15 +186,15 @@ classdef HankelHermite < ParaxialBeam
             hgBeam = HermiteBeam(w0, lambda, n, m);
             nhgBeam = NHermiteBeam(w0, lambda, n, m);
 
-            HGx = hgBeam.opticalField(X, Y, z);
-            NHx = nhgBeam.opticalField(X, Y, z);
+            HGx = hgBeam.opticalField(X, Y, z_scalar);
+            NHx = nhgBeam.opticalField(X, Y, z_scalar);
 
             % For y, reuse same beams with swapped orders
             hgBeam_y = HermiteBeam(w0, lambda, m, n);
             nhgBeam_y = NHermiteBeam(w0, lambda, m, n);
 
-            HGy = hgBeam_y.opticalField(X, Y, z);
-            NHy = nhgBeam_y.opticalField(X, Y, z);
+            HGy = hgBeam_y.opticalField(X, Y, z_scalar);
+            NHy = nhgBeam_y.opticalField(X, Y, z_scalar);
 
             % Hankel combination per type
             switch ht
@@ -214,6 +221,8 @@ classdef HankelHermite < ParaxialBeam
         end
 
         function params = getParameters(obj, z)
+            % Ensure z is scalar (may be passed as matrix from RayBundle.z)
+            if ~isscalar(z), z = z(1); end
             params = GaussianParameters(z, obj.InitialWaist, obj.Lambda);
         end
 
@@ -286,12 +295,15 @@ function field = hankelHermiteField(X, Y, w0, lambda, n, m, z, hankelType)
     % Uses both independent series solutions [HG, NHG] of the Hermite
     % differential equation, obtained via HermiteParameters.getHermiteSolutions.
 
+    % Ensure z is scalar (may be passed as matrix from RayBundle.z)
+    if ~isscalar(z), z = z(1); end
+
     k  = 2*pi/lambda;
     zr = pi * w0.^2 ./ lambda;
 
     w   = w0 .* sqrt(1 + (z./zr).^2);
     Rc  = z  .* (1 + (zr./z).^2);
-    Rc(z == 0) = Inf;
+    if z == 0, Rc = Inf; end
     psi = atan2(z, zr);
 
     % Gaussian carrier field u_0(r,z)

--- a/+paraxial/+beams/HankelLaguerre.m
+++ b/+paraxial/+beams/HankelLaguerre.m
@@ -272,16 +272,19 @@ classdef HankelLaguerre < ParaxialBeam
             ht     = obj.HankelType;
             zr     = pi * w0^2 / lambda;
 
-            w   = w0 * sqrt(1 + (z/zr)^2);
-            Rc  = z  * (1 + (zr/z)^2);
-            if z == 0, Rc = Inf; end
-            psi = atan2(z, zr);
+            % Ensure z is scalar (RayBundle may pass matrix z)
+            z_scalar = z(1);
+
+            w   = w0 * sqrt(1 + (z_scalar/zr)^2);
+            Rc  = z_scalar * (1 + (zr/z_scalar)^2);
+            if z_scalar == 0, Rc = Inf; end
+            psi = atan2(z_scalar, zr);
 
             % Gaussian carrier field u_0(r,z)
             [TH, R] = cart2pol(X, Y);
             r          = R;
             amplitude  = (w0 ./ w) .* exp(-r.^2 ./ w.^2);
-            phase_z    = -1i * k * z;
+            phase_z    = -1i * k * z_scalar;
             phase_curv = 1i * k * r.^2 ./ (2 * Rc);
             phase_curv(isinf(Rc)) = 0;
             phase_gouy = -1i * psi;
@@ -294,8 +297,8 @@ classdef HankelLaguerre < ParaxialBeam
             lbBeam  = LaguerreBeam(w0, lambda, l, p);
             xlgBeam = XLaguerreBeam(w0, lambda, l, p);
 
-            LB  = lbBeam.opticalField(X, Y, z);
-            XLG = xlgBeam.opticalField(X, Y, z);
+            LB  = lbBeam.opticalField(X, Y, z_scalar);
+            XLG = xlgBeam.opticalField(X, Y, z_scalar);
 
             % Hankel superposition
             if ht == 1
@@ -314,6 +317,9 @@ end
 function field = hankelField(r, theta, w0, lambda, l, p, z, hankelType)
     % hankelField - Compute H^(1) or H^(2) Hankel-Laguerre field at depth z.
     %
+    % Ensure z is scalar (may be passed as matrix from RayBundle.z)
+    if ~isscalar(z), z = z(1); end
+
     % Project phase convention (same as LaguerreBeam):
     %   exp(-i*k*z) axial carrier.
     % Therefore, total LG phase is:

--- a/+paraxial/+propagation/+rays/RayTracePropagator.m
+++ b/+paraxial/+propagation/+rays/RayTracePropagator.m
@@ -1,4 +1,4 @@
-classdef RayTracePropagator < paraxial.propagation.field.IPropagator
+classdef RayTracePropagator < IPropagator
     % RayTracePropagator - Phase-gradient ray tracing via RayTracer (Strategy)
     % Compatible with GNU Octave and MATLAB
     %


### PR DESCRIPTION
Bug: HankelHermite and HankelLaguerre field calculations failed when z was passed as a matrix (e.g., from RayBundle.z(:,:,end)) instead of a scalar. This caused dimension mismatches in phase calculations.

Fix:
- Extract z_scalar = z(1) at start of field computation
- Use z_scalar for all scalar operations (w, Rc, psi, phase_z, etc.)
- Apply to hankelHermiteField_composed, hankelField_composed, hankelHermiteField (module-private), and hankelField (module-private)
- Fix RayTracePropagator classdef to use short-form IPropagator (consistent with AnalyticPropagator and FFTPropagator)

Tests: test_Propagators (25/25), test_HankelRayTracing (20/20)